### PR TITLE
fix(5.1-compat): Removes use of table.pack(...) in favour of [...]

### DIFF
--- a/fnl/lightspeed.fnl
+++ b/fnl/lightspeed.fnl
@@ -25,7 +25,7 @@
 (macro one-of? [x ...]
   "Expands to an `or` form, like (or (= x y1) (= x y2) ...)"
   `(or ,(unpack 
-          (icollect [_ y (ipairs (table.pack ...))]
+          (icollect [_ y (ipairs [...])]
             `(= ,x ,y)))))
 
 (macro when-not [condition ...]


### PR DESCRIPTION
The macro `one-of?` uses `table.pack`, which is unavailable in lua 5.1.

The same effect can be achieved by using {...} (in lua) or [...] (in fennel), and this is compatible with 5.1 - 5.4 as far as I can tell (testing in each repl).

I assume you probably have your shell Lua set to 5.1+ and since it's a macro, it's never an issue. I only noticed because I wanted to compile Lightspeed via Hotpot, which runs in a 5.1 env.

`{...}` won't handle trailing nils in true multivar args but I don't think that matters in this case, see http://lua-users.org/wiki/VarargTheSecondClassCitizen (ctrl-f {...}). There is another implementation that places an `:n` key but I don't think it matters.

Thoughts?