### PR TITLE
feat(s): temporarily disable hlsearch during 2-character search

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ require'lightspeed'.setup {
   -- turn it on only if your machine can always cope with it.
   highlight_unique_chars = false,
   grey_out_search_area = true,
+  disable_hlsearch = true,
   match_only_the_start_of_same_char_seqs = true,
   limit_ft_matches = 5,
   x_mode_prefix_key = '<c-x>',

--- a/fnl/lightspeed.fnl
+++ b/fnl/lightspeed.fnl
@@ -117,6 +117,7 @@ character instead."
            :jump_on_partial_input_safety_timeout 400
            :highlight_unique_chars false
            :grey_out_search_area true
+           :disable_hlsearch true
            :match_only_the_start_of_same_char_seqs true
            :limit_ft_matches 5
            :x_mode_prefix_key "<c-x>"
@@ -157,7 +158,9 @@ character instead."
              (api.nvim_buf_add_highlight 0 self.ns hl-group line startcol endcol))
    :set-extmark (fn [self line col opts]
                   (api.nvim_buf_set_extmark 0 self.ns line col opts))
-   :cleanup (fn [self] (api.nvim_buf_clear_namespace 0 self.ns 0 -1))})
+   :cleanup (fn [self]
+   (api.nvim_buf_clear_namespace 0 self.ns 0 -1)
+   (when opts.disable_hlsearch (vim.cmd "let &hlsearch=&hlsearch")))})
 
 
 (fn init-highlight []
@@ -852,6 +855,7 @@ with `ch1` in separate ordered lists, keyed by the succeeding char."
     (macro with-hl-chores [...]
       `(do (when opts.grey_out_search_area (grey-out-search-area reverse?))
            (do ,...)
+           (when opts.disable_hlsearch (vim.cmd :nohlsearch))
            (highlight-cursor)
            (vim.cmd :redraw)))
 

--- a/lua/lightspeed.lua
+++ b/lua/lightspeed.lua
@@ -19,16 +19,16 @@ local function last(tbl)
 end
 local empty_3f = vim.tbl_isempty
 local function reverse_lookup(tbl)
-  local tbl_9_auto = {}
+  local tbl_10_auto = {}
   for k, v in ipairs(tbl) do
     local _2_, _3_ = v, k
     if ((nil ~= _2_) and (nil ~= _3_)) then
-      local k_10_auto = _2_
-      local v_11_auto = _3_
-      tbl_9_auto[k_10_auto] = v_11_auto
+      local k_11_auto = _2_
+      local v_12_auto = _3_
+      tbl_10_auto[k_11_auto] = v_12_auto
     end
   end
-  return tbl_9_auto
+  return tbl_10_auto
 end
 local function getchar_as_str()
   local ok_3f, ch = pcall(vim.fn.getchar)
@@ -86,7 +86,7 @@ local function leftmost_editable_wincol()
   vim.fn.winrestview(view)
   return wincol
 end
-local opts = {cycle_group_bwd_key = nil, cycle_group_fwd_key = nil, grey_out_search_area = true, highlight_unique_chars = false, instant_repeat_bwd_key = nil, instant_repeat_fwd_key = nil, jump_on_partial_input_safety_timeout = 400, jump_to_first_match = true, labels = nil, limit_ft_matches = 5, match_only_the_start_of_same_char_seqs = true, substitute_chars = {["\13"] = "\194\172"}, x_mode_prefix_key = "<c-x>"}
+local opts = {jump_to_first_match = true, jump_on_partial_input_safety_timeout = 400, highlight_unique_chars = false, grey_out_search_area = true, disable_hlsearch = true, match_only_the_start_of_same_char_seqs = true, limit_ft_matches = 5, x_mode_prefix_key = "<c-x>", substitute_chars = {["\13"] = "\194\172"}, instant_repeat_fwd_key = nil, instant_repeat_bwd_key = nil, cycle_group_fwd_key = nil, cycle_group_bwd_key = nil, labels = nil}
 local function setup(user_opts)
   opts = setmetatable(user_opts, {__index = opts})
   return nil
@@ -99,133 +99,136 @@ local function _12_(self, line, col, opts0)
   return api.nvim_buf_set_extmark(0, self.ns, line, col, opts0)
 end
 local function _13_(self)
-  return api.nvim_buf_clear_namespace(0, self.ns, 0, -1)
+  api.nvim_buf_clear_namespace(0, self.ns, 0, -1)
+  if opts.disable_hlsearch then
+    return vim.cmd("let &hlsearch=&hlsearch")
+  end
 end
-hl = {["add-hl"] = _11_, ["set-extmark"] = _12_, cleanup = _13_, group = {["label-distant"] = "LightspeedLabelDistant", ["label-distant-overlapped"] = "LightspeedLabelDistantOverlapped", ["label-overlapped"] = "LightspeedLabelOverlapped", ["masked-ch"] = "LightspeedMaskedChar", ["one-char-match"] = "LightspeedOneCharMatch", ["pending-change-op-area"] = "LightspeedPendingChangeOpArea", ["pending-op-area"] = "LightspeedPendingOpArea", ["shortcut-overlapped"] = "LightspeedShortcutOverlapped", ["unique-ch"] = "LightspeedUniqueChar", ["unlabeled-match"] = "LightspeedUnlabeledMatch", cursor = "LightspeedCursor", greywash = "LightspeedGreyWash", label = "LightspeedLabel", shortcut = "LightspeedShortcut"}, ns = api.nvim_create_namespace("")}
+hl = {group = {label = "LightspeedLabel", ["label-distant"] = "LightspeedLabelDistant", ["label-overlapped"] = "LightspeedLabelOverlapped", ["label-distant-overlapped"] = "LightspeedLabelDistantOverlapped", shortcut = "LightspeedShortcut", ["shortcut-overlapped"] = "LightspeedShortcutOverlapped", ["masked-ch"] = "LightspeedMaskedChar", ["unlabeled-match"] = "LightspeedUnlabeledMatch", ["one-char-match"] = "LightspeedOneCharMatch", ["unique-ch"] = "LightspeedUniqueChar", ["pending-op-area"] = "LightspeedPendingOpArea", ["pending-change-op-area"] = "LightspeedPendingChangeOpArea", greywash = "LightspeedGreyWash", cursor = "LightspeedCursor"}, ns = api.nvim_create_namespace(""), ["add-hl"] = _11_, ["set-extmark"] = _12_, cleanup = _13_}
 local function init_highlight()
   local bg = vim.o.background
   local groupdefs
-  local _15_
+  local _16_
   do
-    local _14_ = bg
-    if (_14_ == "light") then
-      _15_ = "#f02077"
+    local _15_ = bg
+    if (_15_ == "light") then
+      _16_ = "#f02077"
     else
-      local _ = _14_
-      _15_ = "#ff2f87"
+      local _ = _15_
+      _16_ = "#ff2f87"
     end
   end
-  local _20_
+  local _21_
   do
-    local _19_ = bg
-    if (_19_ == "light") then
-      _20_ = "#ff4090"
+    local _20_ = bg
+    if (_20_ == "light") then
+      _21_ = "#ff4090"
     else
-      local _ = _19_
-      _20_ = "#e01067"
+      local _ = _20_
+      _21_ = "#e01067"
     end
   end
-  local _25_
+  local _26_
   do
-    local _24_ = bg
-    if (_24_ == "light") then
-      _25_ = "Blue"
+    local _25_ = bg
+    if (_25_ == "light") then
+      _26_ = "#399d9f"
     else
-      local _ = _24_
-      _25_ = "Cyan"
+      local _ = _25_
+      _26_ = "#99ddff"
     end
   end
-  local _30_
+  local _31_
   do
-    local _29_ = bg
-    if (_29_ == "light") then
-      _30_ = "#399d9f"
+    local _30_ = bg
+    if (_30_ == "light") then
+      _31_ = "Blue"
     else
-      local _ = _29_
-      _30_ = "#99ddff"
+      local _ = _30_
+      _31_ = "Cyan"
     end
   end
-  local _35_
+  local _36_
   do
-    local _34_ = bg
-    if (_34_ == "light") then
-      _35_ = "Cyan"
+    local _35_ = bg
+    if (_35_ == "light") then
+      _36_ = "#59bdbf"
     else
-      local _ = _34_
-      _35_ = "Blue"
+      local _ = _35_
+      _36_ = "#79bddf"
     end
   end
-  local _40_
+  local _41_
   do
-    local _39_ = bg
-    if (_39_ == "light") then
-      _40_ = "#59bdbf"
+    local _40_ = bg
+    if (_40_ == "light") then
+      _41_ = "Cyan"
     else
-      local _ = _39_
-      _40_ = "#79bddf"
+      local _ = _40_
+      _41_ = "Blue"
     end
   end
-  local _45_
+  local _46_
   do
-    local _44_ = bg
-    if (_44_ == "light") then
-      _45_ = "#cc9999"
+    local _45_ = bg
+    if (_45_ == "light") then
+      _46_ = "#cc9999"
     else
-      local _ = _44_
-      _45_ = "#b38080"
+      local _ = _45_
+      _46_ = "#b38080"
     end
   end
-  local _50_
+  local _51_
   do
-    local _49_ = bg
-    if (_49_ == "light") then
-      _50_ = "Black"
+    local _50_ = bg
+    if (_50_ == "light") then
+      _51_ = "#272020"
     else
-      local _ = _49_
-      _50_ = "White"
+      local _ = _50_
+      _51_ = "#f3ecec"
     end
   end
-  local _55_
+  local _56_
   do
-    local _54_ = bg
-    if (_54_ == "light") then
-      _55_ = "#272020"
+    local _55_ = bg
+    if (_55_ == "light") then
+      _56_ = "Black"
     else
-      local _ = _54_
-      _55_ = "#f3ecec"
+      local _ = _55_
+      _56_ = "White"
     end
   end
-  local _60_
+  local _61_
   do
-    local _59_ = bg
-    if (_59_ == "light") then
-      _60_ = "#f02077"
+    local _60_ = bg
+    if (_60_ == "light") then
+      _61_ = "#f02077"
     else
-      local _ = _59_
-      _60_ = "#ff2f87"
+      local _ = _60_
+      _61_ = "#ff2f87"
     end
   end
-  groupdefs = {{hl.group.label, {cterm = "bold,underline", ctermfg = "Red", gui = "bold,underline", guifg = _15_}}, {hl.group["label-overlapped"], {cterm = "underline", ctermfg = "Magenta", gui = "underline", guifg = _20_}}, {hl.group["label-distant"], {cterm = "bold,underline", ctermfg = _25_, gui = "bold,underline", guifg = _30_}}, {hl.group["label-distant-overlapped"], {cterm = "underline", ctermfg = _35_, gui = "underline", guifg = _40_}}, {hl.group.shortcut, {cterm = "bold,underline", ctermbg = "Red", ctermfg = "White", gui = "bold,underline", guibg = "#f00077", guifg = "#ffffff"}}, {hl.group["one-char-match"], {cterm = "bold", ctermbg = "Red", ctermfg = "White", gui = "bold", guibg = "#f00077", guifg = "#ffffff"}}, {hl.group["masked-ch"], {ctermfg = "DarkGrey", guifg = _45_}}, {hl.group["unlabeled-match"], {cterm = "bold", ctermfg = _50_, gui = "bold", guifg = _55_}}, {hl.group["pending-op-area"], {ctermbg = "Red", ctermfg = "White", guibg = "#f00077", guifg = "#ffffff"}}, {hl.group["pending-change-op-area"], {cterm = "strikethrough", ctermfg = "Red", gui = "strikethrough", guifg = _60_}}, {hl.group.greywash, {ctermfg = "Grey", guifg = "#777777"}}}
-  for _, _64_ in ipairs(groupdefs) do
-    local _each_65_ = _64_
-    local group = _each_65_[1]
-    local attrs = _each_65_[2]
+  groupdefs = {{hl.group.label, {guifg = _16_, ctermfg = "Red", gui = "bold,underline", cterm = "bold,underline"}}, {hl.group["label-overlapped"], {guifg = _21_, ctermfg = "Magenta", gui = "underline", cterm = "underline"}}, {hl.group["label-distant"], {guifg = _26_, ctermfg = _31_, gui = "bold,underline", cterm = "bold,underline"}}, {hl.group["label-distant-overlapped"], {guifg = _36_, ctermfg = _41_, gui = "underline", cterm = "underline"}}, {hl.group.shortcut, {guibg = "#f00077", ctermbg = "Red", guifg = "#ffffff", ctermfg = "White", gui = "bold,underline", cterm = "bold,underline"}}, {hl.group["one-char-match"], {guibg = "#f00077", ctermbg = "Red", guifg = "#ffffff", ctermfg = "White", gui = "bold", cterm = "bold"}}, {hl.group["masked-ch"], {guifg = _46_, ctermfg = "DarkGrey"}}, {hl.group["unlabeled-match"], {guifg = _51_, ctermfg = _56_, gui = "bold", cterm = "bold"}}, {hl.group["pending-op-area"], {guibg = "#f00077", ctermbg = "Red", guifg = "#ffffff", ctermfg = "White"}}, {hl.group["pending-change-op-area"], {guifg = _61_, ctermfg = "Red", gui = "strikethrough", cterm = "strikethrough"}}, {hl.group.greywash, {guifg = "#777777", ctermfg = "Grey"}}}
+  for _, _65_ in ipairs(groupdefs) do
+    local _each_66_ = _65_
+    local group = _each_66_[1]
+    local attrs = _each_66_[2]
     local attrs_str
-    local _66_
+    local _67_
     do
-      local tbl_12_auto = {}
+      local tbl_13_auto = {}
       for k, v in pairs(attrs) do
-        tbl_12_auto[(#tbl_12_auto + 1)] = (k .. "=" .. v)
+        tbl_13_auto[(#tbl_13_auto + 1)] = (k .. "=" .. v)
       end
-      _66_ = tbl_12_auto
+      _67_ = tbl_13_auto
     end
-    attrs_str = table.concat(_66_, " ")
+    attrs_str = table.concat(_67_, " ")
     vim.cmd(("highlight default " .. group .. " " .. attrs_str))
   end
-  for _, _67_ in ipairs({{hl.group["unique-ch"], hl.group["unlabeled-match"]}, {hl.group["shortcut-overlapped"], hl.group.shortcut}, {hl.group.cursor, "Cursor"}}) do
-    local _each_68_ = _67_
-    local from_group = _each_68_[1]
-    local to_group = _each_68_[2]
+  for _, _68_ in ipairs({{hl.group["unique-ch"], hl.group["unlabeled-match"]}, {hl.group["shortcut-overlapped"], hl.group.shortcut}, {hl.group.cursor, "Cursor"}}) do
+    local _each_69_ = _68_
+    local from_group = _each_69_[1]
+    local to_group = _each_69_[2]
     vim.cmd(("highlight default link " .. from_group .. " " .. to_group))
   end
   return nil
@@ -239,22 +242,22 @@ local function add_highlight_autocmds()
 end
 add_highlight_autocmds()
 local function grey_out_search_area(reverse_3f)
-  local _let_69_ = vim.tbl_map(dec, get_cursor_pos())
-  local curline = _let_69_[1]
-  local curcol = _let_69_[2]
-  local _let_70_ = {dec(vim.fn.line("w0")), dec(vim.fn.line("w$"))}
-  local win_top = _let_70_[1]
-  local win_bot = _let_70_[2]
-  local function _72_()
+  local _let_70_ = vim.tbl_map(dec, get_cursor_pos())
+  local curline = _let_70_[1]
+  local curcol = _let_70_[2]
+  local _let_71_ = {dec(vim.fn.line("w0")), dec(vim.fn.line("w$"))}
+  local win_top = _let_71_[1]
+  local win_bot = _let_71_[2]
+  local function _73_()
     if reverse_3f then
       return {{win_top, 0}, {curline, curcol}}
     else
       return {{curline, inc(curcol)}, {win_bot, -1}}
     end
   end
-  local _let_71_ = _72_()
-  local start = _let_71_[1]
-  local finish = _let_71_[2]
+  local _let_72_ = _73_()
+  local start = _let_72_[1]
+  local finish = _let_72_[2]
   return vim.highlight.range(0, hl.ns, hl.group.greywash, start, finish)
 end
 local function echo_no_prev_search()
@@ -264,18 +267,18 @@ local function echo_not_found(s)
   return echo(("not found: " .. s))
 end
 local function push_cursor_21(direction)
-  local _74_
+  local _75_
   do
-    local _73_ = direction
-    if (_73_ == "fwd") then
-      _74_ = "W"
-    elseif (_73_ == "bwd") then
-      _74_ = "bW"
+    local _74_ = direction
+    if (_74_ == "fwd") then
+      _75_ = "W"
+    elseif (_74_ == "bwd") then
+      _75_ = "bW"
     else
-    _74_ = nil
+    _75_ = nil
     end
   end
-  return vim.fn.search("\\_.", _74_, __fnl_global___3fstopline)
+  return vim.fn.search("\\_.", _75_, __fnl_global___3fstopline)
 end
 local function cursor_before_eof_3f()
   return ((vim.fn.line(".") == vim.fn.line("$")) and (vim.fn.virtcol(".") == dec(vim.fn.virtcol("$"))))
@@ -284,10 +287,10 @@ local function force_matchparen_refresh()
   vim.cmd("silent! doautocmd matchparen CursorMoved")
   return vim.cmd("silent! doautocmd matchup_matchparen CursorMoved")
 end
-local function onscreen_match_positions(pattern, reverse_3f, _78_)
-  local _arg_79_ = _78_
-  local ft_search_3f = _arg_79_["ft-search?"]
-  local limit = _arg_79_["limit"]
+local function onscreen_match_positions(pattern, reverse_3f, _79_)
+  local _arg_80_ = _79_
+  local ft_search_3f = _arg_80_["ft-search?"]
+  local limit = _arg_80_["limit"]
   local view = vim.fn.winsaveview()
   local cpo = vim.o.cpo
   local opts0
@@ -297,82 +300,82 @@ local function onscreen_match_positions(pattern, reverse_3f, _78_)
     opts0 = ""
   end
   local stopline
-  local function _81_()
+  local function _82_()
     if reverse_3f then
       return "w0"
     else
       return "w$"
     end
   end
-  stopline = vim.fn.line(_81_())
+  stopline = vim.fn.line(_82_())
   local cleanup
-  local function _82_()
+  local function _83_()
     vim.fn.winrestview(view)
     vim.o.cpo = cpo
     return nil
   end
-  cleanup = _82_
+  cleanup = _83_
   local non_editable_width = dec(leftmost_editable_wincol())
   local col_in_edit_area = (vim.fn.wincol() - non_editable_width)
   local left_bound = (vim.fn.col(".") - dec(col_in_edit_area))
   local window_width = api.nvim_win_get_width(0)
   local right_bound = (left_bound + dec((window_width - non_editable_width - 1)))
   local function skip_to_fold_edge_21()
-    local _83_
     local _84_
+    local _85_
     if reverse_3f then
-      _84_ = vim.fn.foldclosed
+      _85_ = vim.fn.foldclosed
     else
-      _84_ = vim.fn.foldclosedend
+      _85_ = vim.fn.foldclosedend
     end
-    _83_ = _84_(vim.fn.line("."))
-    if (_83_ == -1) then
+    _84_ = _85_(vim.fn.line("."))
+    if (_84_ == -1) then
       return "not-in-fold"
-    elseif (nil ~= _83_) then
-      local fold_edge = _83_
+    elseif (nil ~= _84_) then
+      local fold_edge = _84_
       vim.fn.cursor(fold_edge, 0)
-      local function _86_()
+      local function _87_()
         if reverse_3f then
           return 1
         else
           return vim.fn.col("$")
         end
       end
-      vim.fn.cursor(0, _86_())
+      vim.fn.cursor(0, _87_())
       return "moved-the-cursor"
     end
   end
   local function skip_to_next_onscreen_pos_21()
-    local _local_88_ = get_cursor_pos()
-    local line = _local_88_[1]
-    local col = _local_88_[2]
-    local from_pos = _local_88_
-    local _89_
+    local _local_89_ = get_cursor_pos()
+    local line = _local_89_[1]
+    local col = _local_89_[2]
+    local from_pos = _local_89_
+    local _90_
     if (col < left_bound) then
       if reverse_3f then
         if (dec(line) >= stopline) then
-          _89_ = {dec(line), right_bound}
+          _90_ = {dec(line), right_bound}
         else
-        _89_ = nil
+        _90_ = nil
         end
       else
-        _89_ = {line, left_bound}
+        _90_ = {line, left_bound}
       end
     elseif (col > right_bound) then
       if reverse_3f then
-        _89_ = {line, right_bound}
+        _90_ = {line, right_bound}
       else
         if (inc(line) <= stopline) then
-          _89_ = {inc(line), left_bound}
+          _90_ = {inc(line), left_bound}
         else
-        _89_ = nil
+        _90_ = nil
         end
       end
     else
-    _89_ = nil
+    _90_ = nil
     end
-    if (nil ~= _89_) then
-      local to_pos = _89_
+    if (nil ~= _90_) then
+      local to_pos = _90_
       if (from_pos ~= to_pos) then
         vim.fn.cursor(to_pos)
         return "moved-the-cursor"
@@ -385,21 +388,22 @@ local function onscreen_match_positions(pattern, reverse_3f, _78_)
     if (limit and (match_count >= limit)) then
       return cleanup()
     else
-      local _97_
       local _98_
-      if match_at_curpos_3f then
-        _98_ = "c"
-      else
-        _98_ = ""
+      local function _99_()
+        if match_at_curpos_3f then
+          return "c"
+        else
+          return ""
+        end
       end
-      _97_ = vim.fn.searchpos(pattern, (opts0 .. _98_), stopline)
-      if ((type(_97_) == "table") and ((_97_)[1] == 0) and true) then
-        local _ = (_97_)[2]
+      _98_ = vim.fn.searchpos(pattern, (opts0 .. _99_()), stopline)
+      if ((_G.type(_98_) == "table") and ((_98_)[1] == 0) and true) then
+        local _ = (_98_)[2]
         return cleanup()
-      elseif ((type(_97_) == "table") and (nil ~= (_97_)[1]) and (nil ~= (_97_)[2])) then
-        local line = (_97_)[1]
-        local col = (_97_)[2]
-        local pos = _97_
+      elseif ((_G.type(_98_) == "table") and (nil ~= (_98_)[1]) and (nil ~= (_98_)[2])) then
+        local line = (_98_)[1]
+        local col = (_98_)[2]
+        local pos = _98_
         if ft_search_3f then
           match_count = (match_count + 1)
           return pos
@@ -459,7 +463,7 @@ local function highlight_cursor(_3fpos)
   local col = _let_118_[2]
   local pos = _let_118_
   local ch_at_curpos = (char_at_pos(pos, {}) or " ")
-  return hl["set-extmark"](hl, dec(line), dec(col), {hl_mode = "combine", virt_text = {{ch_at_curpos, hl.group.cursor}}, virt_text_pos = "overlay"})
+  return hl["set-extmark"](hl, dec(line), dec(col), {virt_text = {{ch_at_curpos, hl.group.cursor}}, virt_text_pos = "overlay", hl_mode = "combine"})
 end
 local function handle_interrupted_change_op_21()
   echo("")
@@ -503,7 +507,7 @@ local function set_dot_repeat(cmd, _3fcount)
     end
   end
 end
-local ft = {["instant-repeat?"] = nil, ["prev-dot-repeatable-search"] = nil, ["prev-reverse?"] = nil, ["prev-search"] = nil, ["prev-t-like?"] = nil, ["started-reverse?"] = nil, stack = {}}
+local ft = {["instant-repeat?"] = nil, ["started-reverse?"] = nil, ["prev-reverse?"] = nil, ["prev-t-like?"] = nil, ["prev-search"] = nil, ["prev-dot-repeatable-search"] = nil, stack = {}}
 ft.to = function(self, reverse_3f, t_like_3f, dot_repeat_3f, revert_3f)
   local _
   if not self["instant-repeat?"] then
@@ -682,37 +686,39 @@ ft.to = function(self, reverse_3f, t_like_3f, dot_repeat_3f, revert_3f)
           mode = "x"
         end
         local repeat_3f
-        local _159_
-        if t_like_3f then
-          _159_ = "t"
-        else
-          _159_ = "f"
+        local function _159_()
+          if t_like_3f then
+            return "t"
+          else
+            return "f"
+          end
         end
-        repeat_3f = ((in2 == repeat_key) or string.match(vim.fn.maparg(in2, mode), ("<Plug>Lightspeed_" .. _159_)))
+        repeat_3f = ((in2 == repeat_key) or string.match(vim.fn.maparg(in2, mode), ("<Plug>Lightspeed_" .. _159_())))
         local revert_3f0
-        local _161_
-        if t_like_3f then
-          _161_ = "T"
-        else
-          _161_ = "F"
+        local function _160_()
+          if t_like_3f then
+            return "T"
+          else
+            return "F"
+          end
         end
-        revert_3f0 = ((in2 == revert_key) or string.match(vim.fn.maparg(in2, mode), ("<Plug>Lightspeed_" .. _161_)))
+        revert_3f0 = ((in2 == revert_key) or string.match(vim.fn.maparg(in2, mode), ("<Plug>Lightspeed_" .. _160_())))
         hl:cleanup()
         self["instant-repeat?"] = (ok_3f and (repeat_3f or revert_3f0))
         if not self["instant-repeat?"] then
           self.stack = {}
-          local _163_
+          local _161_
           if ok_3f then
-            _163_ = in2
+            _161_ = in2
           else
-            _163_ = replace_keycodes("<esc>")
+            _161_ = replace_keycodes("<esc>")
           end
-          return vim.fn.feedkeys(_163_, "i")
+          return vim.fn.feedkeys(_161_, "i")
         else
           if revert_3f0 then
-            local _165_ = table.remove(self.stack)
-            if (nil ~= _165_) then
-              local prev_pos = _165_
+            local _163_ = table.remove(self.stack)
+            if (nil ~= _163_) then
+              local prev_pos = _163_
               vim.fn.cursor(prev_pos)
             end
           else
@@ -725,31 +731,31 @@ ft.to = function(self, reverse_3f, t_like_3f, dot_repeat_3f, revert_3f)
   end
 end
 local function get_labels()
-  local function _172_()
+  local function _170_()
     if opts.jump_to_first_match then
       return {"s", "f", "n", "/", "u", "t", "q", "S", "F", "G", "H", "L", "M", "N", "?", "U", "R", "Z", "T", "Q"}
     else
       return {"f", "j", "d", "k", "s", "l", "a", ";", "e", "i", "w", "o", "g", "h", "v", "n", "c", "m", "z", "."}
     end
   end
-  return (opts.labels or _172_())
+  return (opts.labels or _170_())
 end
 local function get_cycle_keys()
-  local function _173_()
+  local function _171_()
     if opts.jump_to_first_match then
       return "<tab>"
     else
       return "<space>"
     end
   end
-  local function _174_()
+  local function _172_()
     if opts.jump_to_first_match then
       return "<s-tab>"
     else
       return "<tab>"
     end
   end
-  return vim.tbl_map(replace_keycodes, {(opts.cycle_group_fwd_key or _173_()), (opts.cycle_group_bwd_key or _174_())})
+  return vim.tbl_map(replace_keycodes, {(opts.cycle_group_fwd_key or _171_()), (opts.cycle_group_bwd_key or _172_())})
 end
 local function get_match_map_for(ch1, reverse_3f)
   local match_map = {}
@@ -758,27 +764,28 @@ local function get_match_map_for(ch1, reverse_3f)
   local pattern = (prefix .. input .. "\\_.")
   local match_count = 0
   local prev = {}
-  for _175_ in onscreen_match_positions(pattern, reverse_3f, {}) do
-    local _each_176_ = _175_
-    local line = _each_176_[1]
-    local col = _each_176_[2]
-    local pos = _each_176_
+  for _173_ in onscreen_match_positions(pattern, reverse_3f, {}) do
+    local _each_174_ = _173_
+    local line = _each_174_[1]
+    local col = _each_174_[2]
+    local pos = _each_174_
     local overlap_with_prev_3f
-    local _177_
+    local _175_
     if reverse_3f then
-      _177_ = dec
+      _175_ = dec
     else
-      _177_ = inc
+      _175_ = inc
     end
-    overlap_with_prev_3f = ((line == prev.line) and (col == _177_(prev.col)))
+    overlap_with_prev_3f = ((line == prev.line) and (col == _175_(prev.col)))
     local ch2 = (char_at_pos(pos, {["char-offset"] = 1}) or "\13")
     local same_pair_3f = (ch2 == prev.ch2)
-    local function _179_()
-      if not opts.match_only_the_start_of_same_char_seqs then
-        return prev["skipped?"]
-      end
+    local _177_
+    if not opts.match_only_the_start_of_same_char_seqs then
+      _177_ = prev["skipped?"]
+    else
+    _177_ = nil
     end
-    if (_179_() or not (overlap_with_prev_3f and same_pair_3f)) then
+    if (_177_ or not (overlap_with_prev_3f and same_pair_3f)) then
       local partially_covered_3f = (overlap_with_prev_3f and not reverse_3f)
       if not match_map[ch2] then
         match_map[ch2] = {}
@@ -787,44 +794,45 @@ local function get_match_map_for(ch1, reverse_3f)
       if (overlap_with_prev_3f and reverse_3f) then
         last(match_map[prev.ch2])[3] = true
       end
-      prev = {["skipped?"] = false, ch2 = ch2, col = col, line = line}
+      prev = {line = line, col = col, ch2 = ch2, ["skipped?"] = false}
       match_count = (match_count + 1)
     else
-      prev = {["skipped?"] = true, ch2 = ch2, col = col, line = line}
+      prev = {line = line, col = col, ch2 = ch2, ["skipped?"] = true}
     end
   end
-  local _183_ = match_count
-  if (_183_ == 0) then
+  local _182_ = match_count
+  if (_182_ == 0) then
     return nil
-  elseif (_183_ == 1) then
+  elseif (_182_ == 1) then
     local ch2 = vim.tbl_keys(match_map)[1]
     local pos = vim.tbl_values(match_map)[1][1]
     return {ch2, pos}
   else
-    local _ = _183_
+    local _ = _182_
     return match_map
   end
 end
-local function set_beacon_at(_185_, ch1, ch2, _187_)
-  local _arg_186_ = _185_
-  local line = _arg_186_[1]
-  local col = _arg_186_[2]
-  local partially_covered_3f = _arg_186_[3]
-  local pos = _arg_186_
-  local _arg_188_ = _187_
-  local distant_3f = _arg_188_["distant?"]
-  local init_round_3f = _arg_188_["init-round?"]
-  local labeled_3f = _arg_188_["labeled?"]
-  local repeat_3f = _arg_188_["repeat?"]
-  local shortcut_3f = _arg_188_["shortcut?"]
+local function set_beacon_at(_184_, ch1, ch2, _186_)
+  local _arg_185_ = _184_
+  local line = _arg_185_[1]
+  local col = _arg_185_[2]
+  local partially_covered_3f = _arg_185_[3]
+  local pos = _arg_185_
+  local _arg_187_ = _186_
+  local labeled_3f = _arg_187_["labeled?"]
+  local init_round_3f = _arg_187_["init-round?"]
+  local repeat_3f = _arg_187_["repeat?"]
+  local distant_3f = _arg_187_["distant?"]
+  local shortcut_3f = _arg_187_["shortcut?"]
   local ch10 = (opts.substitute_chars[ch1] or ch1)
   local ch20
-  local function _189_()
-    if not labeled_3f then
-      return opts.substitute_chars[ch2]
-    end
+  local _188_
+  if not labeled_3f then
+    _188_ = opts.substitute_chars[ch2]
+  else
+  _188_ = nil
   end
-  ch20 = (_189_() or ch2)
+  ch20 = (_188_ or ch2)
   local partially_covered_3f0
   if not repeat_3f then
     partially_covered_3f0 = partially_covered_3f
@@ -897,7 +905,7 @@ local function set_beacon_groups(ch2, positions, labels, shortcuts, _198_)
       else
       shortcut_3f = nil
       end
-      set_beacon_at(pos, ch2, label, {["distant?"] = distant_3f, ["init-round?"] = init_round_3f, ["labeled?"] = true, ["repeat?"] = repeat_3f, ["shortcut?"] = shortcut_3f})
+      set_beacon_at(pos, ch2, label, {["labeled?"] = true, ["init-round?"] = init_round_3f, ["distant?"] = distant_3f, ["repeat?"] = repeat_3f, ["shortcut?"] = shortcut_3f})
     end
     return nil
   end
@@ -968,7 +976,7 @@ local function get_shortcuts(match_map, labels, reverse_3f, jump_to_first_3f)
   local lookup_by_pos
   do
     local labels_used_up = {}
-    local tbl_9_auto = {}
+    local tbl_10_auto = {}
     for _, _219_ in ipairs(shortcuts) do
       local _each_220_ = _219_
       local pos = _each_220_[1]
@@ -982,28 +990,28 @@ local function get_shortcuts(match_map, labels, reverse_3f, jump_to_first_3f)
       _221_, _222_ = nil
       end
       if ((nil ~= _221_) and (nil ~= _222_)) then
-        local k_10_auto = _221_
-        local v_11_auto = _222_
-        tbl_9_auto[k_10_auto] = v_11_auto
+        local k_11_auto = _221_
+        local v_12_auto = _222_
+        tbl_10_auto[k_11_auto] = v_12_auto
       end
     end
-    lookup_by_pos = tbl_9_auto
+    lookup_by_pos = tbl_10_auto
   end
   local lookup_by_label
   do
-    local tbl_9_auto = {}
+    local tbl_10_auto = {}
     for pos, _225_ in pairs(lookup_by_pos) do
       local _each_226_ = _225_
       local label = _each_226_[1]
       local ch2 = _each_226_[2]
       local _227_, _228_ = label, {pos, ch2}
       if ((nil ~= _227_) and (nil ~= _228_)) then
-        local k_10_auto = _227_
-        local v_11_auto = _228_
-        tbl_9_auto[k_10_auto] = v_11_auto
+        local k_11_auto = _227_
+        local v_12_auto = _228_
+        tbl_10_auto[k_11_auto] = v_12_auto
       end
     end
-    lookup_by_label = tbl_9_auto
+    lookup_by_label = tbl_10_auto
   end
   return vim.tbl_extend("error", lookup_by_pos, lookup_by_label)
 end
@@ -1017,7 +1025,7 @@ local function ignore_char_until_timeout(char_to_ignore)
     end
   end
 end
-local s = {["prev-dot-repeatable-search"] = {["x-mode?"] = nil, in1 = nil, in2 = nil, in3 = nil}, ["prev-search"] = {in1 = nil, in2 = nil}}
+local s = {["prev-search"] = {in1 = nil, in2 = nil}, ["prev-dot-repeatable-search"] = {in1 = nil, in2 = nil, in3 = nil, ["x-mode?"] = nil}}
 s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
   local op_mode_3f = operator_pending_mode_3f()
   local change_op_3f = change_operation_3f()
@@ -1031,21 +1039,22 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
   local label_indexes = reverse_lookup(labels)
   local jump_to_first_3f = (opts.jump_to_first_match and not op_mode_3f)
   local cmd_for_dot_repeat
-  local _233_
-  if arg_x_mode_3f then
-    if reverse_3f then
-      _233_ = "X"
+  local function _235_()
+    if arg_x_mode_3f then
+      if reverse_3f then
+        return "X"
+      else
+        return "x"
+      end
     else
-      _233_ = "x"
-    end
-  else
-    if reverse_3f then
-      _233_ = "S"
-    else
-      _233_ = "s"
+      if reverse_3f then
+        return "S"
+      else
+        return "s"
+      end
     end
   end
-  cmd_for_dot_repeat = replace_keycodes(("<Plug>Lightspeed_dotrepeat_" .. _233_))
+  cmd_for_dot_repeat = replace_keycodes(("<Plug>Lightspeed_dotrepeat_" .. _235_()))
   local enter_repeat_3f = nil
   local new_search_3f = nil
   local x_mode_3f = nil
@@ -1073,11 +1082,12 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
     local group_offset = 0
     local loop_3f = true
     while loop_3f do
+      local _239_
       local _240_
-      local function _241_()
-        if dot_repeat_3f then
-          return self["prev-dot-repeatable-search"].in3
-        end
+      if dot_repeat_3f then
+        _240_ = self["prev-dot-repeatable-search"].in3
+      else
+      _240_ = nil
       end
       local function _242_()
         loop_3f = false
@@ -1085,9 +1095,9 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
         ret = nil
         return nil
       end
-      _240_ = (_241_() or get_input_and_clean_up() or _242_())
-      if (nil ~= _240_) then
-        local input = _240_
+      _239_ = (_240_ or get_input_and_clean_up() or _242_())
+      if (nil ~= _239_) then
+        local input = _239_
         if not ((input == cycle_fwd_key) or (input == cycle_bwd_key)) then
           loop_3f = false
           ret = {group_offset, input}
@@ -1110,6 +1120,9 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
           do
             set_beacon_groups(in2, positions_to_label, labels, shortcuts, {["group-offset"] = group_offset, ["repeat?"] = enter_repeat_3f0})
           end
+          if opts.disable_hlsearch then
+            vim.cmd("nohlsearch")
+          end
           highlight_cursor()
           vim.cmd("redraw")
         end
@@ -1117,10 +1130,10 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
     end
     return ret
   end
-  local function save_state_for(_251_)
-    local _arg_252_ = _251_
-    local dot_repeat = _arg_252_["dot-repeat"]
-    local enter_repeat = _arg_252_["enter-repeat"]
+  local function save_state_for(_252_)
+    local _arg_253_ = _252_
+    local enter_repeat = _arg_253_["enter-repeat"]
+    local dot_repeat = _arg_253_["dot-repeat"]
     if new_search_3f then
       if dot_repeatable_op_3f then
         if dot_repeat then
@@ -1137,7 +1150,7 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
   local jump_with_wrap_21
   do
     local first_jump_3f = true
-    local function _256_(target)
+    local function _257_(target)
       do
         local op_mode_3f_4_auto = operator_pending_mode_3f()
         local restore_virtualedit_autocmd_5_auto = ("autocmd CursorMoved,WinLeave,BufLeave" .. ",InsertEnter,CmdlineEnter,CmdwinEnter" .. " * ++once set virtualedit=" .. vim.o.virtualedit)
@@ -1152,10 +1165,10 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
           end
         end
         if (op_mode_3f_4_auto and not reverse_3f and (x_mode_3f and not reverse_3f)) then
-          local _260_ = string.sub(vim.fn.mode("t"), -1)
-          if (_260_ == "v") then
+          local _261_ = string.sub(vim.fn.mode("t"), -1)
+          if (_261_ == "v") then
             push_cursor_21("bwd")
-          elseif (_260_ == "o") then
+          elseif (_261_ == "o") then
             if not cursor_before_eof_3f() then
               push_cursor_21("fwd")
             else
@@ -1175,14 +1188,14 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
       first_jump_3f = false
       return nil
     end
-    jump_with_wrap_21 = _256_
+    jump_with_wrap_21 = _257_
   end
-  local function jump_and_ignore_ch2_until_timeout_21(_266_, ch2)
-    local _arg_267_ = _266_
-    local target_line = _arg_267_[1]
-    local target_col = _arg_267_[2]
-    local _ = _arg_267_[3]
-    local target_pos = _arg_267_
+  local function jump_and_ignore_ch2_until_timeout_21(_267_, ch2)
+    local _arg_268_ = _267_
+    local target_line = _arg_268_[1]
+    local target_col = _arg_268_[2]
+    local _ = _arg_268_[3]
+    local target_pos = _arg_268_
     local orig_pos = get_cursor_pos()
     jump_with_wrap_21(target_pos)
     if new_search_3f then
@@ -1192,7 +1205,7 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
       local forced_motion = string.sub(vim.fn.mode("t"), -1)
       local from_pos = vim.tbl_map(dec, orig_pos)
       local to_pos
-      local function _268_()
+      local function _269_()
         if backward_x_3f then
           return inc(inc(target_col))
         elseif forward_x_3f then
@@ -1201,29 +1214,29 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
           return target_col
         end
       end
-      to_pos = vim.tbl_map(dec, {target_line, _268_()})
-      local function _270_()
+      to_pos = vim.tbl_map(dec, {target_line, _269_()})
+      local function _271_()
         if reverse_3f then
           return to_pos
         else
           return from_pos
         end
       end
-      local _let_269_ = _270_()
-      local startline = _let_269_[1]
-      local startcol = _let_269_[2]
-      local start = _let_269_
-      local function _272_()
+      local _let_270_ = _271_()
+      local startline = _let_270_[1]
+      local startcol = _let_270_[2]
+      local start = _let_270_
+      local function _273_()
         if reverse_3f then
           return from_pos
         else
           return to_pos
         end
       end
-      local _let_271_ = _272_()
-      local endline = _let_271_[1]
-      local endcol = _let_271_[2]
-      local _end = _let_271_
+      local _let_272_ = _273_()
+      local endline = _let_272_[1]
+      local endcol = _let_272_[2]
+      local _end = _let_272_
       if not change_op_3f then
         local _3fpos_to_highlight_at
         if op_mode_3f then
@@ -1250,31 +1263,31 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
         local function hl_range(start0, _end0)
           return vim.highlight.range(0, hl.ns, hl_group, start0, _end0)
         end
-        local _277_ = forced_motion
-        if (_277_ == ctrl_v) then
+        local _278_ = forced_motion
+        if (_278_ == ctrl_v) then
           for line = startline, endline do
             hl_range({line, math.min(startcol, endcol)}, {line, inc(math.max(startcol, endcol))})
           end
-        elseif (_277_ == "V") then
+        elseif (_278_ == "V") then
           hl_range({startline, 0}, {endline, -1})
-        elseif (_277_ == "v") then
-          local function _278_()
-            if inclusive_motion_3f then
-              return endcol
-            else
-              return inc(endcol)
-            end
-          end
-          hl_range(start, {endline, _278_()})
-        elseif (_277_ == "o") then
+        elseif (_278_ == "v") then
           local function _279_()
             if inclusive_motion_3f then
-              return inc(endcol)
-            else
               return endcol
+            else
+              return inc(endcol)
             end
           end
           hl_range(start, {endline, _279_()})
+        elseif (_278_ == "o") then
+          local function _280_()
+            if inclusive_motion_3f then
+              return inc(endcol)
+            else
+              return endcol
+            end
+          end
+          hl_range(start, {endline, _280_()})
         end
       end
       vim.cmd("redraw")
@@ -1295,22 +1308,25 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
         highlight_unique_chars(reverse_3f)
       end
     end
+    if opts.disable_hlsearch then
+      vim.cmd("nohlsearch")
+    end
     highlight_cursor()
     vim.cmd("redraw")
   end
-  local _287_
+  local _289_
   if dot_repeat_3f then
     x_mode_3f = self["prev-dot-repeatable-search"]["x-mode?"]
-    _287_ = self["prev-dot-repeatable-search"].in1
+    _289_ = self["prev-dot-repeatable-search"].in1
   else
-    local _288_ = get_input_and_clean_up()
-    if (nil ~= _288_) then
-      local in0 = _288_
+    local _290_ = get_input_and_clean_up()
+    if (nil ~= _290_) then
+      local in0 = _290_
       enter_repeat_3f = (in0 == "\13")
       new_search_3f = not (enter_repeat_3f or dot_repeat_3f)
       x_mode_3f = (arg_x_mode_3f or (in0 == x_mode_prefix_key))
       if enter_repeat_3f then
-        local function _289_()
+        local function _291_()
           if change_operation_3f() then
             handle_interrupted_change_op_21()
           end
@@ -1319,25 +1335,25 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
           end
           return nil
         end
-        _287_ = (self["prev-search"].in1 or _289_())
+        _289_ = (self["prev-search"].in1 or _291_())
       elseif (x_mode_3f and not arg_x_mode_3f) then
-        _287_ = get_input_and_clean_up()
+        _289_ = get_input_and_clean_up()
       else
-        _287_ = in0
+        _289_ = in0
       end
     else
-    _287_ = nil
+    _289_ = nil
     end
   end
-  if (nil ~= _287_) then
-    local in1 = _287_
-    local _294_
-    local function _295_()
+  if (nil ~= _289_) then
+    local in1 = _289_
+    local _296_
+    local function _297_()
       if change_operation_3f() then
         handle_interrupted_change_op_21()
       end
       do
-        local function _297_()
+        local function _299_()
           if enter_repeat_3f then
             return (in1 .. self["prev-search"].in2)
           elseif dot_repeat_3f then
@@ -1346,16 +1362,16 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
             return in1
           end
         end
-        echo_not_found(_297_())
+        echo_not_found(_299_())
       end
       return nil
     end
-    _294_ = (get_match_map_for(in1, reverse_3f) or _295_())
-    if ((type(_294_) == "table") and (nil ~= (_294_)[1]) and (nil ~= (_294_)[2])) then
-      local ch2 = (_294_)[1]
-      local pos = (_294_)[2]
+    _296_ = (get_match_map_for(in1, reverse_3f) or _297_())
+    if ((_G.type(_296_) == "table") and (nil ~= (_296_)[1]) and (nil ~= (_296_)[2])) then
+      local ch2 = (_296_)[1]
+      local pos = (_296_)[2]
       if (new_search_3f or (enter_repeat_3f and (ch2 == self["prev-search"].in2)) or (dot_repeat_3f and (ch2 == self["prev-dot-repeatable-search"].in2))) then
-        save_state_for({["dot-repeat"] = {in1 = in1, in2 = ch2, in3 = labels[1]}, ["enter-repeat"] = {in1 = in1, in2 = ch2}})
+        save_state_for({["enter-repeat"] = {in1 = in1, in2 = ch2}, ["dot-repeat"] = {in1 = in1, in2 = ch2, in3 = labels[1]}})
         return jump_and_ignore_ch2_until_timeout_21(pos, ch2)
       else
         if change_operation_3f() then
@@ -1366,8 +1382,8 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
         end
         return nil
       end
-    elseif (nil ~= _294_) then
-      local match_map = _294_
+    elseif (nil ~= _296_) then
+      local match_map = _296_
       local shortcuts = get_shortcuts(match_map, labels, reverse_3f, jump_to_first_3f)
       if new_search_3f then
         if opts.grey_out_search_area then
@@ -1375,9 +1391,9 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
         end
         do
           for ch2, positions in pairs(match_map) do
-            local _let_301_ = positions
-            local first = _let_301_[1]
-            local rest = {(table.unpack or unpack)(_let_301_, 2)}
+            local _let_303_ = positions
+            local first = _let_303_[1]
+            local rest = {(table.unpack or unpack)(_let_303_, 2)}
             local positions_to_label
             if jump_to_first_3f then
               positions_to_label = rest
@@ -1392,34 +1408,37 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
             end
           end
         end
+        if opts.disable_hlsearch then
+          vim.cmd("nohlsearch")
+        end
         highlight_cursor()
         vim.cmd("redraw")
       end
-      local _306_
+      local _309_
       if enter_repeat_3f then
-        _306_ = self["prev-search"].in2
+        _309_ = self["prev-search"].in2
       elseif dot_repeat_3f then
-        _306_ = self["prev-dot-repeatable-search"].in2
+        _309_ = self["prev-dot-repeatable-search"].in2
       else
-        _306_ = get_input_and_clean_up()
+        _309_ = get_input_and_clean_up()
       end
-      if (nil ~= _306_) then
-        local in2 = _306_
-        local _308_
+      if (nil ~= _309_) then
+        local in2 = _309_
+        local _311_
         if new_search_3f then
-          _308_ = shortcuts[in2]
+          _311_ = shortcuts[in2]
         else
-        _308_ = nil
+        _311_ = nil
         end
-        if ((type(_308_) == "table") and (nil ~= (_308_)[1]) and (nil ~= (_308_)[2])) then
-          local pos = (_308_)[1]
-          local ch2 = (_308_)[2]
-          save_state_for({["dot-repeat"] = {in1 = in1, in2 = ch2, in3 = in2}, ["enter-repeat"] = {in1 = in1, in2 = ch2}})
+        if ((_G.type(_311_) == "table") and (nil ~= (_311_)[1]) and (nil ~= (_311_)[2])) then
+          local pos = (_311_)[1]
+          local ch2 = (_311_)[2]
+          save_state_for({["enter-repeat"] = {in1 = in1, in2 = ch2}, ["dot-repeat"] = {in1 = in1, in2 = ch2, in3 = in2}})
           return jump_with_wrap_21(pos)
-        elseif (_308_ == nil) then
-          save_state_for({["dot-repeat"] = {in1 = in1, in2 = in2, in3 = labels[1]}, ["enter-repeat"] = {in1 = in1, in2 = in2}})
-          local _310_
-          local function _311_()
+        elseif (_311_ == nil) then
+          save_state_for({["enter-repeat"] = {in1 = in1, in2 = in2}, ["dot-repeat"] = {in1 = in1, in2 = in2, in3 = labels[1]}})
+          local _313_
+          local function _314_()
             if change_operation_3f() then
               handle_interrupted_change_op_21()
             end
@@ -1428,12 +1447,12 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
             end
             return nil
           end
-          _310_ = (match_map[in2] or _311_())
-          if (nil ~= _310_) then
-            local positions = _310_
-            local _let_313_ = positions
-            local first = _let_313_[1]
-            local rest = {(table.unpack or unpack)(_let_313_, 2)}
+          _313_ = (match_map[in2] or _314_())
+          if (nil ~= _313_) then
+            local positions = _313_
+            local _let_316_ = positions
+            local first = _let_316_[1]
+            local rest = {(table.unpack or unpack)(_let_316_, 2)}
             local positions_to_label
             if jump_to_first_3f then
               positions_to_label = rest
@@ -1452,13 +1471,16 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
                 do
                   set_beacon_groups(in2, positions_to_label, labels, shortcuts, {["repeat?"] = enter_repeat_3f})
                 end
+                if opts.disable_hlsearch then
+                  vim.cmd("nohlsearch")
+                end
                 highlight_cursor()
                 vim.cmd("redraw")
               end
-              local _318_ = cycle_through_match_groups(in2, positions_to_label, shortcuts, enter_repeat_3f)
-              if ((type(_318_) == "table") and (nil ~= (_318_)[1]) and (nil ~= (_318_)[2])) then
-                local group_offset = (_318_)[1]
-                local in3 = (_318_)[2]
+              local _322_ = cycle_through_match_groups(in2, positions_to_label, shortcuts, enter_repeat_3f)
+              if ((_G.type(_322_) == "table") and (nil ~= (_322_)[1]) and (nil ~= (_322_)[2])) then
+                local group_offset = (_322_)[1]
+                local in3 = (_322_)[2]
                 restore_scrolloff()
                 if (dot_repeatable_op_3f and not dot_repeat_3f) then
                   if (group_offset == 0) then
@@ -1467,21 +1489,22 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
                     self["prev-dot-repeatable-search"].in3 = nil
                   end
                 end
-                local _321_
-                local function _323_()
-                  local _322_ = label_indexes[in3]
-                  if _322_ then
-                    local _324_ = ((group_offset * #labels) + _322_)
-                    if _324_ then
-                      return positions_to_label[_324_]
+                local _325_
+                local _327_
+                do
+                  local _326_ = label_indexes[in3]
+                  if _326_ then
+                    local _328_ = ((group_offset * #labels) + _326_)
+                    if _328_ then
+                      _327_ = positions_to_label[_328_]
                     else
-                      return _324_
+                      _327_ = _328_
                     end
                   else
-                    return _322_
+                    _327_ = _326_
                   end
                 end
-                local function _327_()
+                local function _332_()
                   if change_operation_3f() then
                     handle_interrupted_change_op_21()
                   end
@@ -1492,9 +1515,9 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
                   end
                   return nil
                 end
-                _321_ = (_323_() or _327_())
-                if (nil ~= _321_) then
-                  local pos = _321_
+                _325_ = (_327_ or _332_())
+                if (nil ~= _325_) then
+                  local pos = _325_
                   return jump_with_wrap_21(pos)
                 end
               end
@@ -1506,20 +1529,20 @@ s.to = function(self, reverse_3f, arg_x_mode_3f, dot_repeat_3f)
   end
 end
 local plug_mappings = {{"n", "<Plug>Lightspeed_s", "s:to(false)"}, {"n", "<Plug>Lightspeed_S", "s:to(true)"}, {"x", "<Plug>Lightspeed_s", "s:to(false)"}, {"x", "<Plug>Lightspeed_S", "s:to(true)"}, {"o", "<Plug>Lightspeed_s", "s:to(false)"}, {"o", "<Plug>Lightspeed_S", "s:to(true)"}, {"n", "<Plug>Lightspeed_x", "s:to(false, true)"}, {"n", "<Plug>Lightspeed_X", "s:to(true, true)"}, {"x", "<Plug>Lightspeed_x", "s:to(false, true)"}, {"x", "<Plug>Lightspeed_X", "s:to(true, true)"}, {"o", "<Plug>Lightspeed_x", "s:to(false, true)"}, {"o", "<Plug>Lightspeed_X", "s:to(true, true)"}, {"n", "<Plug>Lightspeed_f", "ft:to(false)"}, {"n", "<Plug>Lightspeed_F", "ft:to(true)"}, {"x", "<Plug>Lightspeed_f", "ft:to(false)"}, {"x", "<Plug>Lightspeed_F", "ft:to(true)"}, {"o", "<Plug>Lightspeed_f", "ft:to(false)"}, {"o", "<Plug>Lightspeed_F", "ft:to(true)"}, {"x", "<Plug>Lightspeed_t", "ft:to(false, true)"}, {"x", "<Plug>Lightspeed_T", "ft:to(true, true)"}, {"n", "<Plug>Lightspeed_t", "ft:to(false, true)"}, {"n", "<Plug>Lightspeed_T", "ft:to(true, true)"}, {"o", "<Plug>Lightspeed_t", "ft:to(false, true)"}, {"o", "<Plug>Lightspeed_T", "ft:to(true, true)"}, {"o", "<Plug>Lightspeed_dotrepeat_s", "s:to(false, false, true)"}, {"o", "<Plug>Lightspeed_dotrepeat_S", "s:to(true, false, true)"}, {"o", "<Plug>Lightspeed_dotrepeat_x", "s:to(false, true, true)"}, {"o", "<Plug>Lightspeed_dotrepeat_X", "s:to(true, true, true)"}, {"o", "<Plug>Lightspeed_dotrepeat_f", "ft:to(false, false, true)"}, {"o", "<Plug>Lightspeed_dotrepeat_F", "ft:to(true, false, true)"}, {"o", "<Plug>Lightspeed_dotrepeat_t", "ft:to(false, true, true)"}, {"o", "<Plug>Lightspeed_dotrepeat_T", "ft:to(true, true, true)"}}
-for _, _338_ in ipairs(plug_mappings) do
-  local _each_339_ = _338_
-  local mode = _each_339_[1]
-  local lhs = _each_339_[2]
-  local rhs_call = _each_339_[3]
+for _, _343_ in ipairs(plug_mappings) do
+  local _each_344_ = _343_
+  local mode = _each_344_[1]
+  local lhs = _each_344_[2]
+  local rhs_call = _each_344_[3]
   api.nvim_set_keymap(mode, lhs, ("<cmd>lua require'lightspeed'." .. rhs_call .. "<cr>"), {noremap = true, silent = true})
 end
 local function add_default_mappings()
   local default_mappings = {{"n", "s", "<Plug>Lightspeed_s"}, {"n", "S", "<Plug>Lightspeed_S"}, {"x", "s", "<Plug>Lightspeed_s"}, {"x", "S", "<Plug>Lightspeed_S"}, {"o", "z", "<Plug>Lightspeed_s"}, {"o", "Z", "<Plug>Lightspeed_S"}, {"o", "x", "<Plug>Lightspeed_x"}, {"o", "X", "<Plug>Lightspeed_X"}, {"n", "f", "<Plug>Lightspeed_f"}, {"n", "F", "<Plug>Lightspeed_F"}, {"x", "f", "<Plug>Lightspeed_f"}, {"x", "F", "<Plug>Lightspeed_F"}, {"o", "f", "<Plug>Lightspeed_f"}, {"o", "F", "<Plug>Lightspeed_F"}, {"n", "t", "<Plug>Lightspeed_t"}, {"n", "T", "<Plug>Lightspeed_T"}, {"x", "t", "<Plug>Lightspeed_t"}, {"x", "T", "<Plug>Lightspeed_T"}, {"o", "t", "<Plug>Lightspeed_t"}, {"o", "T", "<Plug>Lightspeed_T"}}
-  for _, _340_ in ipairs(default_mappings) do
-    local _each_341_ = _340_
-    local mode = _each_341_[1]
-    local lhs = _each_341_[2]
-    local rhs = _each_341_[3]
+  for _, _345_ in ipairs(default_mappings) do
+    local _each_346_ = _345_
+    local mode = _each_346_[1]
+    local lhs = _each_346_[2]
+    local rhs = _each_346_[3]
     if ((vim.fn.mapcheck(lhs, mode) == "") and (vim.fn.hasmapto(rhs, mode) == 0)) then
       api.nvim_set_keymap(mode, lhs, rhs, {silent = true})
     end
@@ -1527,4 +1550,4 @@ local function add_default_mappings()
   return nil
 end
 add_default_mappings()
-return {add_default_mappings = add_default_mappings, ft = ft, init_highlight = init_highlight, opts = opts, s = s, setup = setup}
+return {opts = opts, setup = setup, init_highlight = init_highlight, ft = ft, s = s, add_default_mappings = add_default_mappings}


### PR DESCRIPTION
Disable the highlighting on /-search matches during the 2-character
search. The highlighting is reenabled after the jump. This feature can 
be activated/deactivated with `opts.disable_hlsearch`.