### PR TITLE
allow disabling default keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ defaults.)
 
 ```Lua
 require'lightspeed'.setup {
+  ignore_case = false,
   exit_after_idle_msecs = { labeled = nil, unlabeled = 1000 },
 
   -- s/x
@@ -616,14 +617,12 @@ nnoremap <expr> g/ '/<C-u>\%>'.(col(".")-v:count1).'v\%<'.(col(".")+v:count1).'v
 nnoremap <expr> g? '?<C-u>\%>'.(col(".")-v:count1).'v\%<'.(col(".")+v:count1).'v'
 ```
 
-### Case insensitivity for 2-character search?
+### Smart case?
 
-See [#64](https://github.com/ggandor/lightspeed.nvim/issues/64). TL;DR:
-`smartcase`-like behaviour would be super-useful, but is unfortunately
-impossible for this plugin, _by design_. At the same time, the value of a plain
-"ignore case" setting is questionable, because that would mean ignoring our
-clever "shortcutting" features too. Here, capitals can very frequently make you
-reach the target faster - so start using them!
+See [#64](https://github.com/ggandor/lightspeed.nvim/issues/64). It is
+unfortunately impossible for this plugin, _by design_. (Because of ahead-of-time
+labeling, it would require showing two different labels - corresponding to two
+different futures - at the same time.)
 
 ### Arbitrary-length search pattern?
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Temporary fork
+This fork was created just to allow disabling default bindings
+It will be kept updated with upstream until either:
+- Proper default binding settings are implemented upstream
+- I'm not using it anymore
+
 # 🌌 lightspeed.nvim
 
 Lightspeed is a cutting-edge motion plugin for [Neovim](https://neovim.io/),

--- a/doc/lightspeed.txt
+++ b/doc/lightspeed.txt
@@ -1,4 +1,4 @@
-*lightspeed.txt*     For Neovim version 0.5.0      Last change: 2021 December 13
+*lightspeed.txt*     For Neovim version 0.5.0      Last change: 2021 December 19
 
                     .-.. .. --. .... - ... .--. . . -.. 
                   __   _      __   __                      __
@@ -153,6 +153,10 @@ Setting multiple options via the `setup` function: >
           not mentioned here are not disturbed.)
 
 Common options~
+
+`ignore_case = false`
+
+    Ignore case in search patterns.
 
 `exit_after_idle_msecs = { labeled = nil, unlabeled = 1000 }`
 

--- a/fnl/lightspeed.fnl
+++ b/fnl/lightspeed.fnl
@@ -755,7 +755,7 @@ interrupted change-operation."
         (var jump-pos nil)
         (var match-count 0)
         (let [next-pos (vim.fn.searchpos "\\_." (if reverse? :nWb :nW))
-              pattern (if to-eol? "\\n" (.. "\\V" (in1:gsub "\\" "\\\\")))
+              pattern (if to-eol? "\\n" (.. "\\V\\C" (in1:gsub "\\" "\\\\")))
               limit (+ count (get-num-of-matches-to-be-highlighted))]
           (each [[line col &as pos]
                  (onscreen-match-positions pattern reverse? {:ft-search? true : limit})]

--- a/fnl/lightspeed.fnl
+++ b/fnl/lightspeed.fnl
@@ -149,7 +149,9 @@ character instead."
                "/" "F" "L" "N" "H" "G" "M" "U" "T" "?" "Z"])
        {:ignore_case false
         :exit_after_idle_msecs {:labeled nil :unlabeled 1000}
-        :disable-default-mappings true
+        :override_x true
+        :override_s true
+        :override_motion true
         ; s/x
         :grey_out_search_area true
         :highlight_unique_chars true
@@ -209,7 +211,7 @@ character instead."
         (each [_ chunk (ipairs spec-msg)]
           (table.insert msg chunk))
         (table.insert msg ["\n\n"])))
-  msg))
+   msg))
 
 
 ; Prevent setting or accessing deprecated fields directly.
@@ -231,13 +233,117 @@ character instead."
       (api.nvim_echo (get-deprec-msg deprecated-arg-opts) true {}))
     opts))
 
+(fn set-plug-keys []
+  (local plug-keys
+    [
+     ; params: reverse? [x-mode?] [repeat-invoc]
+     ["<Plug>Lightspeed_s" "sx:go(false)"]
+     ["<Plug>Lightspeed_S" "sx:go(true)"]
+     ["<Plug>Lightspeed_x" "sx:go(false, true)"]
+     ["<Plug>Lightspeed_X" "sx:go(true, true)"]
+
+     ; params: reverse? [t-mode?] [repeat-invoc]
+     ["<Plug>Lightspeed_f" "ft:go(false)"]
+     ["<Plug>Lightspeed_F" "ft:go(true)"]
+     ["<Plug>Lightspeed_t" "ft:go(false, true)"]
+     ["<Plug>Lightspeed_T" "ft:go(true, true)"]
+
+     ; "cold" repeat (;/,-like) (`x-mode?` and `t-mode?` will be retrieved from `state`)
+     ; Note: we should not start the name with ft_ or sx_ if using `hasmapto`
+     ; (or we might switch to <plug> names like `<plug>(lightspeed-;-sx)`).
+     ["<Plug>Lightspeed_;_sx" "sx:go(false, nil, 'cold')"]
+     ["<Plug>Lightspeed_,_sx" "sx:go(true, nil, 'cold')"]
+     ["<Plug>Lightspeed_;_ft" "ft:go(false, nil, 'cold')"]
+     ["<Plug>Lightspeed_,_ft" "ft:go(true, nil, 'cold')"]])
+
+  (each [_ [lhs rhs-call] (ipairs plug-keys)]
+    (each [_ mode (ipairs [:n :x :o])]
+      (api.nvim_set_keymap mode lhs (.. "<cmd>lua require'lightspeed'." rhs-call "<cr>")
+                           {:noremap true :silent true})))
+  
+  ; Just for our convenience, to be used here in the script.
+  (each [_ [lhs rhs-call]
+         (ipairs
+           [["<Plug>Lightspeed_dotrepeat_s" "sx:go(false, false, 'dot')"]
+            ["<Plug>Lightspeed_dotrepeat_S" "sx:go(true, false, 'dot')"]
+            ["<Plug>Lightspeed_dotrepeat_x" "sx:go(false, true, 'dot')"]
+            ["<Plug>Lightspeed_dotrepeat_X" "sx:go(true, true, 'dot')"]
+
+            ["<Plug>Lightspeed_dotrepeat_f" "ft:go(false, false, 'dot')"]
+            ["<Plug>Lightspeed_dotrepeat_F" "ft:go(true, false, 'dot')"]
+            ["<Plug>Lightspeed_dotrepeat_t" "ft:go(false, true, 'dot')"]
+            ["<Plug>Lightspeed_dotrepeat_T" "ft:go(true, true, 'dot')"]])]
+    (api.nvim_set_keymap :o lhs (.. "<cmd>lua require'lightspeed'." rhs-call "<cr>")
+                         {:noremap true :silent true})))
+
+(fn set-default-keymaps []
+  (local default-keymaps 
+    [[:n "f" "<Plug>Lightspeed_f"]
+     [:n "F" "<Plug>Lightspeed_F"]
+     [:x "f" "<Plug>Lightspeed_f"]
+     [:x "F" "<Plug>Lightspeed_F"]
+     [:o "f" "<Plug>Lightspeed_f"]
+     [:o "F" "<Plug>Lightspeed_F"]
+
+     [:n "t" "<Plug>Lightspeed_t"]
+     [:n "T" "<Plug>Lightspeed_T"]
+     [:x "t" "<Plug>Lightspeed_t"]
+     [:x "T" "<Plug>Lightspeed_T"]
+     [:o "t" "<Plug>Lightspeed_t"]
+     [:o "T" "<Plug>Lightspeed_T"]
+
+     [:n ";" "<Plug>Lightspeed_;_ft"]
+     [:x ";" "<Plug>Lightspeed_;_ft"]
+     [:o ";" "<Plug>Lightspeed_;_ft"]
+
+     [:n "," "<Plug>Lightspeed_,_ft"]
+     [:x "," "<Plug>Lightspeed_,_ft"]
+     [:o "," "<Plug>Lightspeed_,_ft"]])
+
+  (local override-x-keymaps
+   [[:o "x" "<Plug>Lightspeed_x"]
+    [:o "X" "<Plug>Lightspeed_X"]])
+
+  (local override-s-keymaps
+   [[:n "s" "<Plug>Lightspeed_s"]
+    [:n "S" "<Plug>Lightspeed_S"]
+    [:x "s" "<Plug>Lightspeed_s"]
+    [:x "S" "<Plug>Lightspeed_S"]
+    [:o "z" "<Plug>Lightspeed_s"]
+    [:o "Z" "<Plug>Lightspeed_S"]])
+
+  (if opts.override_motion
+    (each [_ [mode lhs rhs] (ipairs default-keymaps)]
+      (when (and
+              ; user has not mapped (a keyseq starting with) `lhs` to something else.
+              (= (vim.fn.mapcheck lhs mode) "")
+              ; user has not already mapped something to the <plug> key.
+              (= (vim.fn.hasmapto rhs mode) 0))
+        (api.nvim_set_keymap mode lhs rhs {:silent true}))))
+
+  (if opts.override_x
+    (each [_ [mode lhs rhs] (ipairs override-x-keymaps)]
+      (when (and
+              ; user has not mapped (a keyseq starting with) `lhs` to something else.
+              (= (vim.fn.mapcheck lhs mode) "")
+              ; user has not already mapped something to the <plug> key.
+              (= (vim.fn.hasmapto rhs mode) 0))
+        (api.nvim_set_keymap mode lhs rhs))))
+
+  (if opts.override_s
+    (each [_ [mode lhs rhs] (ipairs override-s-keymaps)]
+      (when (and
+              ; user has not mapped (a keyseq starting with) `lhs` to something else.
+              (= (vim.fn.mapcheck lhs mode) "")
+              ; user has not already mapped something to the <plug> key.
+              (= (vim.fn.hasmapto rhs mode) 0))
+        (api.nvim_set_keymap mode lhs rhs {:silent true})))))
 
 (fn setup [user-opts]
-  (when-not (:disable-default-mappings user-opts)
-    (set-default-keymaps))
   (set opts (-> (normalize-opts user-opts)
-                (setmetatable {:__index opts}))))
-
+                (setmetatable {:__index opts})))
+  (set-plug-keys)
+  (set-default-keymaps))
 
 ; Highlight ///1
 
@@ -1256,8 +1362,8 @@ sub-table containing label-target k-v pairs for these targets."
                                                 (do (push-cursor! :fwd)
                                                     (when reverse?
                                                       (push-cursor! :fwd))))})]
-                 (set first-jump? false)
-                 adjusted-pos))))
+                  (set first-jump? false)
+                  adjusted-pos))))
 
     ; Jumping based on partial input is nice, but it's annoying that we
     ; don't see the actual changes right away (we are staying in the main
@@ -1477,97 +1583,10 @@ sub-table containing label-target k-v pairs for these targets."
 
 ; Mappings ///1
 
-(fn set-plug-keys []
-  (local plug-keys
-    [
-     ; params: reverse? [x-mode?] [repeat-invoc]
-     ["<Plug>Lightspeed_s" "sx:go(false)"]
-     ["<Plug>Lightspeed_S" "sx:go(true)"]
-     ["<Plug>Lightspeed_x" "sx:go(false, true)"]
-     ["<Plug>Lightspeed_X" "sx:go(true, true)"]
-
-     ; params: reverse? [t-mode?] [repeat-invoc]
-     ["<Plug>Lightspeed_f" "ft:go(false)"]
-     ["<Plug>Lightspeed_F" "ft:go(true)"]
-     ["<Plug>Lightspeed_t" "ft:go(false, true)"]
-     ["<Plug>Lightspeed_T" "ft:go(true, true)"]
-
-     ; "cold" repeat (;/,-like) (`x-mode?` and `t-mode?` will be retrieved from `state`)
-     ; Note: we should not start the name with ft_ or sx_ if using `hasmapto`
-     ; (or we might switch to <plug> names like `<plug>(lightspeed-;-sx)`).
-     ["<Plug>Lightspeed_;_sx" "sx:go(false, nil, 'cold')"]
-     ["<Plug>Lightspeed_,_sx" "sx:go(true, nil, 'cold')"]
-     ["<Plug>Lightspeed_;_ft" "ft:go(false, nil, 'cold')"]
-     ["<Plug>Lightspeed_,_ft" "ft:go(true, nil, 'cold')"]])
-
-  (each [_ [lhs rhs-call] (ipairs plug-keys)]
-    (each [_ mode (ipairs [:n :x :o])]
-      (api.nvim_set_keymap mode lhs (.. "<cmd>lua require'lightspeed'." rhs-call "<cr>")
-                           {:noremap true :silent true})))
-  
-  ; Just for our convenience, to be used here in the script.
-  (each [_ [lhs rhs-call]
-         (ipairs
-           [["<Plug>Lightspeed_dotrepeat_s" "sx:go(false, false, 'dot')"]
-            ["<Plug>Lightspeed_dotrepeat_S" "sx:go(true, false, 'dot')"]
-            ["<Plug>Lightspeed_dotrepeat_x" "sx:go(false, true, 'dot')"]
-            ["<Plug>Lightspeed_dotrepeat_X" "sx:go(true, true, 'dot')"]
-
-            ["<Plug>Lightspeed_dotrepeat_f" "ft:go(false, false, 'dot')"]
-            ["<Plug>Lightspeed_dotrepeat_F" "ft:go(true, false, 'dot')"]
-            ["<Plug>Lightspeed_dotrepeat_t" "ft:go(false, true, 'dot')"]
-            ["<Plug>Lightspeed_dotrepeat_T" "ft:go(true, true, 'dot')"]])]
-    (api.nvim_set_keymap :o lhs (.. "<cmd>lua require'lightspeed'." rhs-call "<cr>")
-                         {:noremap true :silent true})))
-
-
-(fn set-default-keymaps []
-  (local default-keymaps
-    [[:n "s" "<Plug>Lightspeed_s"]
-     [:n "S" "<Plug>Lightspeed_S"]
-     [:x "s" "<Plug>Lightspeed_s"]
-     [:x "S" "<Plug>Lightspeed_S"]
-     [:o "z" "<Plug>Lightspeed_s"]
-     [:o "Z" "<Plug>Lightspeed_S"]
-
-     [:o "x" "<Plug>Lightspeed_x"]
-     [:o "X" "<Plug>Lightspeed_X"]
-
-     [:n "f" "<Plug>Lightspeed_f"]
-     [:n "F" "<Plug>Lightspeed_F"]
-     [:x "f" "<Plug>Lightspeed_f"]
-     [:x "F" "<Plug>Lightspeed_F"]
-     [:o "f" "<Plug>Lightspeed_f"]
-     [:o "F" "<Plug>Lightspeed_F"]
-
-     [:n "t" "<Plug>Lightspeed_t"]
-     [:n "T" "<Plug>Lightspeed_T"]
-     [:x "t" "<Plug>Lightspeed_t"]
-     [:x "T" "<Plug>Lightspeed_T"]
-     [:o "t" "<Plug>Lightspeed_t"]
-     [:o "T" "<Plug>Lightspeed_T"]
-     
-     [:n ";" "<Plug>Lightspeed_;_ft"]
-     [:x ";" "<Plug>Lightspeed_;_ft"]
-     [:o ";" "<Plug>Lightspeed_;_ft"]
-
-     [:n "," "<Plug>Lightspeed_,_ft"]
-     [:x "," "<Plug>Lightspeed_,_ft"]
-     [:o "," "<Plug>Lightspeed_,_ft"]])
-
-  (each [_ [mode lhs rhs] (ipairs default-keymaps)]
-    (when (and
-            ; User has not mapped (a keyseq starting with) `lhs` to something else.
-            (= (vim.fn.mapcheck lhs mode) "")
-            ; User has not already mapped something to the <Plug> key.
-            (= (vim.fn.hasmapto rhs mode) 0))
-      (api.nvim_set_keymap mode lhs rhs {:silent true}))))
-
 
 ; Init ///1
 
 (init-highlight)
-(set-plug-keys)
 
 
 ; Colorscheme plugins might clear out our highlight definitions, without

--- a/lua/lightspeed.lua
+++ b/lua/lightspeed.lua
@@ -117,7 +117,7 @@ local opts
 do
   local safe_labels = {"s", "f", "n", "u", "t", "/", "F", "L", "N", "H", "G", "M", "U", "T", "?", "Z"}
   local labels = {"s", "f", "n", "j", "k", "l", "o", "i", "w", "e", "h", "g", "u", "t", "m", "v", "c", "a", ".", "z", "/", "F", "L", "N", "H", "G", "M", "U", "T", "?", "Z"}
-  opts = {cycle_group_bwd_key = "<tab>", cycle_group_fwd_key = "<space>", exit_after_idle_msecs = {labeled = nil, unlabeled = 1000}, grey_out_search_area = true, highlight_unique_chars = true, jump_on_partial_input_safety_timeout = 400, labels = labels, limit_ft_matches = 4, match_only_the_start_of_same_char_seqs = true, repeat_ft_with_target_char = false, safe_labels = safe_labels, substitute_chars = {["\13"] = "\194\172"}}
+  opts = {cycle_group_bwd_key = "<tab>", cycle_group_fwd_key = "<space>", exit_after_idle_msecs = {labeled = nil, unlabeled = 1000}, grey_out_search_area = true, highlight_unique_chars = true, ignore_case = false, jump_on_partial_input_safety_timeout = 400, labels = labels, limit_ft_matches = 4, match_only_the_start_of_same_char_seqs = true, repeat_ft_with_target_char = false, safe_labels = safe_labels, substitute_chars = {["\13"] = "\194\172"}}
 end
 local deprecated_opts = {"jump_to_first_match", "instant_repeat_fwd_key", "instant_repeat_bwd_key", "x_mode_prefix_key", "full_inclusive_prefix_key"}
 local function get_deprec_msg(arg_fields)
@@ -941,14 +941,20 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       if to_eol_3f then
         pattern = "\\n"
       else
-        pattern = ("\\V\\C" .. in1:gsub("\\", "\\\\"))
+        local _220_
+        if opts.ignore_case then
+          _220_ = "\\c"
+        else
+          _220_ = "\\C"
+        end
+        pattern = ("\\V" .. _220_ .. in1:gsub("\\", "\\\\"))
       end
       local limit = (count0 + get_num_of_matches_to_be_highlighted())
-      for _221_ in onscreen_match_positions(pattern, reverse_3f0, {["ft-search?"] = true, limit = limit}) do
-        local _each_222_ = _221_
-        local line = _each_222_[1]
-        local col = _each_222_[2]
-        local pos = _each_222_
+      for _223_ in onscreen_match_positions(pattern, reverse_3f0, {["ft-search?"] = true, limit = limit}) do
+        local _each_224_ = _223_
+        local line = _each_224_[1]
+        local col = _each_224_[2]
+        local pos = _each_224_
         if not ((match_count == 0) and cold_repeat_3f and t_mode_3f0 and same_pos_3f(pos, next_pos)) then
           if (match_count <= dec(count0)) then
             jump_pos = pos
@@ -973,22 +979,22 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       return nil
     else
       if not reverted_instant_repeat_3f then
-        local function _227_()
+        local function _229_()
           if t_mode_3f0 then
-            local function _228_()
+            local function _230_()
               if reverse_3f0 then
                 return "fwd"
               else
                 return "bwd"
               end
             end
-            push_cursor_21(_228_())
+            push_cursor_21(_230_())
             if (to_eol_3f and not reverse_3f0 and mode:match("n")) then
               return push_cursor_21("fwd")
             end
           end
         end
-        jump_to_21_2a(jump_pos, {["add-to-jumplist?"] = not instant_repeat_3f, ["inclusive-motion?"] = true, ["reverse?"] = reverse_3f0, adjust = _227_, mode = mode})
+        jump_to_21_2a(jump_pos, {["add-to-jumplist?"] = not instant_repeat_3f, ["inclusive-motion?"] = true, ["reverse?"] = reverse_3f0, adjust = _229_, mode = mode})
       end
       if op_mode_3f then
         do
@@ -1003,8 +1009,8 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       else
         highlight_cursor()
         vim.cmd("redraw")
-        local _233_
-        local function _234_()
+        local _235_
+        local function _236_()
           local res_2_auto
           do
             res_2_auto = get_input(opts.exit_after_idle_msecs.unlabeled)
@@ -1012,46 +1018,46 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
           hl:cleanup()
           return res_2_auto
         end
-        local function _235_()
+        local function _237_()
           do
           end
           doau_when_exists("LightspeedFtLeave")
           doau_when_exists("LightspeedLeave")
           return nil
         end
-        _233_ = (_234_() or _235_())
-        if (nil ~= _233_) then
-          local in2 = _233_
+        _235_ = (_236_() or _237_())
+        if (nil ~= _235_) then
+          local in2 = _235_
           local stack
-          local function _237_()
-            local t_236_ = instant_state
-            if (nil ~= t_236_) then
-              t_236_ = (t_236_).stack
+          local function _239_()
+            local t_238_ = instant_state
+            if (nil ~= t_238_) then
+              t_238_ = (t_238_).stack
             end
-            return t_236_
+            return t_238_
           end
-          stack = (_237_() or {})
+          stack = (_239_() or {})
           local from_reverse_cold_repeat_3f
           if instant_repeat_3f then
             from_reverse_cold_repeat_3f = instant_state["from-reverse-cold-repeat?"]
           else
             from_reverse_cold_repeat_3f = (cold_repeat_3f and invoked_as_reverse_3f)
           end
-          local _240_ = get_repeat_action(in2, "ft", t_mode_3f0, instant_repeat_3f, from_reverse_cold_repeat_3f, in1)
-          if (_240_ == "repeat") then
+          local _242_ = get_repeat_action(in2, "ft", t_mode_3f0, instant_repeat_3f, from_reverse_cold_repeat_3f, in1)
+          if (_242_ == "repeat") then
             table.insert(stack, get_cursor_pos())
             return ft:go(reverse_3f0, t_mode_3f0, {["from-reverse-cold-repeat?"] = from_reverse_cold_repeat_3f, ["in"] = in1, ["reverted?"] = false, stack = stack})
-          elseif (_240_ == "revert") then
+          elseif (_242_ == "revert") then
             do
-              local _241_ = table.remove(stack)
-              if _241_ then
-                vim.fn.cursor(_241_)
+              local _243_ = table.remove(stack)
+              if _243_ then
+                vim.fn.cursor(_243_)
               else
               end
             end
             return ft:go(reverse_3f0, t_mode_3f0, {["from-reverse-cold-repeat?"] = from_reverse_cold_repeat_3f, ["in"] = in1, ["reverted?"] = true, stack = stack})
           else
-            local _ = _240_
+            local _ = _242_
             do
               vim.fn.feedkeys(in2, "i")
             end
@@ -1066,21 +1072,21 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
 end
 do
   local deprec_msg = {{"ligthspeed.nvim", "Question"}, {": You're trying to access deprecated fields in the lightspeed.ft table.\n"}, {"There are dedicated <Plug> keys available for native-like "}, {";", "Visual"}, {" and "}, {",", "Visual"}, {" functionality now.\n"}, {"See "}, {":h lightspeed-custom-mappings", "Visual"}, {"."}}
-  local function _248_(t, k)
+  local function _250_(t, k)
     if ((k == "instant-repeat?") or (k == "prev-t-like?")) then
       return api.nvim_echo(deprec_msg, true, {})
     end
   end
-  setmetatable(ft, {__index = _248_})
+  setmetatable(ft, {__index = _250_})
 end
 local function highlight_unique_chars(reverse_3f)
   local unique_chars = {}
-  local _let_250_ = get_horizontal_bounds({["match-width"] = 2})
-  local left_bound = _let_250_[1]
-  local right_bound = _let_250_[2]
-  local _let_251_ = get_cursor_pos()
-  local curline = _let_251_[1]
-  local curcol = _let_251_[2]
+  local _let_252_ = get_horizontal_bounds({["match-width"] = 2})
+  local left_bound = _let_252_[1]
+  local right_bound = _let_252_[2]
+  local _let_253_ = get_cursor_pos()
+  local curline = _let_253_[1]
+  local curcol = _let_253_[2]
   for lnum, line in pairs(get_onscreen_lines({["reverse?"] = reverse_3f, ["skip-folds?"] = true})) do
     local on_curline_3f = (lnum == curline)
     local startcol
@@ -1098,60 +1104,73 @@ local function highlight_unique_chars(reverse_3f)
     for col = startcol, endcol do
       if (vim.wo.wrap or ((col >= left_bound) and (col <= right_bound))) then
         local ch = line:sub(col, col)
-        local _255_
+        local ch0
+        if opts.ignore_case then
+          ch0 = ch:lower()
+        else
+          ch0 = ch
+        end
+        local _258_
         do
-          local _254_ = unique_chars[ch]
-          if (nil ~= _254_) then
-            local pos_already_there = _254_
-            _255_ = false
+          local _257_ = unique_chars[ch0]
+          if (nil ~= _257_) then
+            local pos_already_there = _257_
+            _258_ = false
           else
-            local _ = _254_
-            _255_ = {lnum, col}
+            local _ = _257_
+            _258_ = {lnum, col}
           end
         end
-        unique_chars[ch] = _255_
+        unique_chars[ch0] = _258_
       end
     end
   end
   for ch, pos in pairs(unique_chars) do
-    local _260_ = pos
-    if ((type(_260_) == "table") and (nil ~= (_260_)[1]) and (nil ~= (_260_)[2])) then
-      local lnum = (_260_)[1]
-      local col = (_260_)[2]
+    local _263_ = pos
+    if ((type(_263_) == "table") and (nil ~= (_263_)[1]) and (nil ~= (_263_)[2])) then
+      local lnum = (_263_)[1]
+      local col = (_263_)[2]
       hl["add-hl"](hl, hl.group["unique-ch"], dec(lnum), dec(col), col)
     end
   end
   return nil
 end
-local function get_targets(ch1, reverse_3f)
+local function get_targets(input, reverse_3f)
   local targets = {}
-  local to_eol_3f = (ch1 == "\13")
+  local to_eol_3f = (input == "\13")
   local prev_match = {}
   local added_prev_match_3f = nil
   local pattern
   if to_eol_3f then
     pattern = "\\n"
   else
-    pattern = ("\\V\\C" .. ch1:gsub("\\", "\\\\") .. "\\_.")
+    local _265_
+    if opts.ignore_case then
+      _265_ = "\\c"
+    else
+      _265_ = "\\C"
+    end
+    pattern = ("\\V" .. _265_ .. input:gsub("\\", "\\\\") .. "\\_.")
   end
-  for _263_ in onscreen_match_positions(pattern, reverse_3f, {["to-eol?"] = to_eol_3f}) do
-    local _each_264_ = _263_
-    local line = _each_264_[1]
-    local col = _each_264_[2]
-    local pos = _each_264_
+  for _268_ in onscreen_match_positions(pattern, reverse_3f, {["to-eol?"] = to_eol_3f}) do
+    local _each_269_ = _268_
+    local line = _each_269_[1]
+    local col = _each_269_[2]
+    local pos = _each_269_
     if to_eol_3f then
       table.insert(targets, {pair = {"\n", ""}, pos = pos})
     else
+      local ch1 = char_at_pos(pos, {})
       local ch2 = (char_at_pos(pos, {["char-offset"] = 1}) or "\13")
       local to_pre_eol_3f = (ch2 == "\13")
       local overlaps_prev_match_3f
-      local _265_
+      local _270_
       if reverse_3f then
-        _265_ = dec
+        _270_ = dec
       else
-        _265_ = inc
+        _270_ = inc
       end
-      overlaps_prev_match_3f = ((line == prev_match.line) and (col == _265_(prev_match.col)))
+      overlaps_prev_match_3f = ((line == prev_match.line) and (col == _270_(prev_match.col)))
       local same_char_triplet_3f = (overlaps_prev_match_3f and (ch2 == prev_match.ch2))
       local overlaps_prev_target_3f = (overlaps_prev_match_3f and added_prev_match_3f)
       prev_match = {ch2 = ch2, col = col, line = line}
@@ -1163,11 +1182,11 @@ local function get_targets(ch1, reverse_3f)
         local match_width = 2
         local touches_prev_target_3f
         do
-          local _267_ = prev_target
-          if ((type(_267_) == "table") and ((type((_267_).pos) == "table") and (nil ~= ((_267_).pos)[1]) and (nil ~= ((_267_).pos)[2]))) then
-            local prev_line = ((_267_).pos)[1]
-            local prev_col = ((_267_).pos)[2]
-            local function _269_()
+          local _272_ = prev_target
+          if ((type(_272_) == "table") and ((type((_272_).pos) == "table") and (nil ~= ((_272_).pos)[1]) and (nil ~= ((_272_).pos)[2]))) then
+            local prev_line = ((_272_).pos)[1]
+            local prev_col = ((_272_).pos)[2]
+            local function _274_()
               local col_delta
               if reverse_3f then
                 col_delta = (prev_col - col)
@@ -1176,7 +1195,7 @@ local function get_targets(ch1, reverse_3f)
               end
               return (col_delta <= match_width)
             end
-            touches_prev_target_3f = ((line == prev_line) and _269_())
+            touches_prev_target_3f = ((line == prev_line) and _274_())
           else
           touches_prev_target_3f = nil
           end
@@ -1185,22 +1204,22 @@ local function get_targets(ch1, reverse_3f)
           target["squeezed?"] = true
         end
         if touches_prev_target_3f then
-          local _272_
+          local _277_
           if reverse_3f then
-            _272_ = target
+            _277_ = target
           else
-            _272_ = prev_target
+            _277_ = prev_target
           end
-          _272_["squeezed?"] = true
+          _277_["squeezed?"] = true
         end
         if overlaps_prev_target_3f then
-          local _275_
+          local _280_
           if reverse_3f then
-            _275_ = prev_target
+            _280_ = prev_target
           else
-            _275_ = target
+            _280_ = target
           end
-          _275_["overlapped?"] = true
+          _280_["overlapped?"] = true
         end
         table.insert(targets, target)
         added_prev_match_3f = true
@@ -1213,16 +1232,28 @@ local function get_targets(ch1, reverse_3f)
 end
 local function populate_sublists(targets)
   targets["sublists"] = {}
-  for _, _281_ in ipairs(targets) do
-    local _each_282_ = _281_
-    local target = _each_282_
-    local _each_283_ = _each_282_["pair"]
-    local _0 = _each_283_[1]
-    local ch2 = _each_283_[2]
-    if not targets.sublists[ch2] then
-      targets["sublists"][ch2] = {}
+  if opts.ignore_case then
+    local function _286_(self, k)
+      return rawget(self, k:lower())
     end
-    table.insert(targets.sublists[ch2], target)
+    setmetatable(targets.sublists, {__index = _286_})
+  end
+  for _, _288_ in ipairs(targets) do
+    local _each_289_ = _288_
+    local target = _each_289_
+    local _each_290_ = _each_289_["pair"]
+    local _0 = _each_290_[1]
+    local ch2 = _each_290_[2]
+    local k
+    if opts.ignore_case then
+      k = ch2:lower()
+    else
+      k = ch2
+    end
+    if not targets.sublists[k] then
+      targets["sublists"][k] = {}
+    end
+    table.insert(targets.sublists[k], target)
   end
   return nil
 end
@@ -1241,12 +1272,12 @@ local function get_labels(sublist, to_eol_3f)
     end
     return opts.safe_labels
   else
-    local _288_ = sublist["autojump?"]
-    if (_288_ == true) then
+    local _296_ = sublist["autojump?"]
+    if (_296_ == true) then
       return opts.safe_labels
-    elseif (_288_ == false) then
+    elseif (_296_ == false) then
       return opts.labels
-    elseif (_288_ == nil) then
+    elseif (_296_ == nil) then
       sublist["autojump?"] = (not operator_pending_mode_3f() and (dec(#sublist) <= #opts.safe_labels))
       return get_labels(sublist)
     end
@@ -1257,63 +1288,63 @@ local function set_labels(targets, to_eol_3f)
     if (#sublist > 1) then
       local labels = get_labels(sublist, to_eol_3f)
       for i, target in ipairs(sublist) do
-        local _291_
+        local _299_
         if not (sublist["autojump?"] and (i == 1)) then
-          local _292_
-          local _294_
+          local _300_
+          local _302_
           if sublist["autojump?"] then
-            _294_ = dec(i)
+            _302_ = dec(i)
           else
-            _294_ = i
+            _302_ = i
           end
-          _292_ = (_294_ % #labels)
-          if (_292_ == 0) then
-            _291_ = last(labels)
-          elseif (nil ~= _292_) then
-            local n = _292_
-            _291_ = labels[n]
+          _300_ = (_302_ % #labels)
+          if (_300_ == 0) then
+            _299_ = last(labels)
+          elseif (nil ~= _300_) then
+            local n = _300_
+            _299_ = labels[n]
           else
-          _291_ = nil
+          _299_ = nil
           end
         else
-        _291_ = nil
+        _299_ = nil
         end
-        target["label"] = _291_
+        target["label"] = _299_
       end
     end
   end
   return nil
 end
-local function set_label_states_for_sublist(sublist, _301_)
-  local _arg_302_ = _301_
-  local group_offset = _arg_302_["group-offset"]
+local function set_label_states_for_sublist(sublist, _309_)
+  local _arg_310_ = _309_
+  local group_offset = _arg_310_["group-offset"]
   local labels = get_labels(sublist)
   local _7clabels_7c = #labels
   local offset = (group_offset * _7clabels_7c)
   local primary_start
-  local _303_
+  local _311_
   if sublist["autojump?"] then
-    _303_ = 2
+    _311_ = 2
   else
-    _303_ = 1
+    _311_ = 1
   end
-  primary_start = (offset + _303_)
+  primary_start = (offset + _311_)
   local primary_end = (primary_start + dec(_7clabels_7c))
   local secondary_end = (primary_end + _7clabels_7c)
   for i, target in ipairs(sublist) do
-    local _305_
+    local _313_
     if target.label then
       if ((i < primary_start) or (i > secondary_end)) then
-        _305_ = "inactive"
+        _313_ = "inactive"
       elseif (i <= primary_end) then
-        _305_ = "active-primary"
+        _313_ = "active-primary"
       else
-        _305_ = "active-secondary"
+        _313_ = "active-secondary"
       end
     else
-    _305_ = nil
+    _313_ = nil
     end
-    target["label-state"] = _305_
+    target["label-state"] = _313_
   end
   return nil
 end
@@ -1329,21 +1360,21 @@ local function set_shortcuts_and_populate_shortcuts_map(targets)
   do
     local tbl_9_auto = {}
     for ch2, _ in pairs(targets.sublists) do
-      local _308_, _309_ = ch2, true
-      if ((nil ~= _308_) and (nil ~= _309_)) then
-        local k_10_auto = _308_
-        local v_11_auto = _309_
+      local _316_, _317_ = ch2, true
+      if ((nil ~= _316_) and (nil ~= _317_)) then
+        local k_10_auto = _316_
+        local v_11_auto = _317_
         tbl_9_auto[k_10_auto] = v_11_auto
       end
     end
     potential_2nd_inputs = tbl_9_auto
   end
   local labels_used_up_as_shortcut = {}
-  for _, _311_ in ipairs(targets) do
-    local _each_312_ = _311_
-    local target = _each_312_
-    local label = _each_312_["label"]
-    local label_state = _each_312_["label-state"]
+  for _, _319_ in ipairs(targets) do
+    local _each_320_ = _319_
+    local target = _each_320_
+    local label = _each_320_["label"]
+    local label_state = _each_320_["label-state"]
     if (label_state == "active-primary") then
       if not ((potential_2nd_inputs)[label] or labels_used_up_as_shortcut[label]) then
         target["shortcut?"] = true
@@ -1354,30 +1385,30 @@ local function set_shortcuts_and_populate_shortcuts_map(targets)
   end
   return nil
 end
-local function set_beacon(_315_, _repeat)
-  local _arg_316_ = _315_
-  local target = _arg_316_
-  local label = _arg_316_["label"]
-  local label_state = _arg_316_["label-state"]
-  local overlapped_3f = _arg_316_["overlapped?"]
-  local _arg_317_ = _arg_316_["pair"]
-  local ch1 = _arg_317_[1]
-  local ch2 = _arg_317_[2]
-  local _arg_318_ = _arg_316_["pos"]
-  local _ = _arg_318_[1]
-  local col = _arg_318_[2]
-  local shortcut_3f = _arg_316_["shortcut?"]
-  local squeezed_3f = _arg_316_["squeezed?"]
+local function set_beacon(_323_, _repeat)
+  local _arg_324_ = _323_
+  local target = _arg_324_
+  local label = _arg_324_["label"]
+  local label_state = _arg_324_["label-state"]
+  local overlapped_3f = _arg_324_["overlapped?"]
+  local _arg_325_ = _arg_324_["pair"]
+  local ch1 = _arg_325_[1]
+  local ch2 = _arg_325_[2]
+  local _arg_326_ = _arg_324_["pos"]
+  local _ = _arg_326_[1]
+  local col = _arg_326_[2]
+  local shortcut_3f = _arg_324_["shortcut?"]
+  local squeezed_3f = _arg_324_["squeezed?"]
   local to_eol_3f = ((ch1 == "\n") and (ch2 == ""))
-  local _let_319_ = get_horizontal_bounds({["match-width"] = 1})
-  local left_bound = _let_319_[1]
-  local right_bound = _let_319_[2]
-  local function _321_(_241)
+  local _let_327_ = get_horizontal_bounds({["match-width"] = 1})
+  local left_bound = _let_327_[1]
+  local right_bound = _let_327_[2]
+  local function _329_(_241)
     return (opts.substitute_chars[_241] or _241)
   end
-  local _let_320_ = map(_321_, {ch1, ch2})
-  local ch10 = _let_320_[1]
-  local ch20 = _let_320_[2]
+  local _let_328_ = map(_329_, {ch1, ch2})
+  local ch10 = _let_328_[1]
+  local ch20 = _let_328_[2]
   local masked_char_24 = {ch20, hl.group["masked-ch"]}
   local label_24 = {label, hl.group.label}
   local shortcut_24 = {label, hl.group.shortcut}
@@ -1386,8 +1417,8 @@ local function set_beacon(_315_, _repeat)
   local overlapped_shortcut_24 = {label, hl.group["shortcut-overlapped"]}
   local overlapped_distant_label_24 = {label, hl.group["label-distant-overlapped"]}
   do
-    local _322_ = label_state
-    if (_322_ == nil) then
+    local _330_ = label_state
+    if (_330_ == nil) then
       if not (_repeat or to_eol_3f) then
         if overlapped_3f then
           target.beacon = {1, {{ch20, hl.group["unlabeled-match"]}}}
@@ -1397,7 +1428,7 @@ local function set_beacon(_315_, _repeat)
       else
       target.beacon = nil
       end
-    elseif (_322_ == "active-primary") then
+    elseif (_330_ == "active-primary") then
       if to_eol_3f then
         if (vim.wo.wrap or ((col <= right_bound) and (col >= left_bound))) then
           target.beacon = {0, {shortcut_24}}
@@ -1409,13 +1440,13 @@ local function set_beacon(_315_, _repeat)
         target.beacon = nil
         end
       elseif _repeat then
-        local _326_
+        local _334_
         if squeezed_3f then
-          _326_ = 1
+          _334_ = 1
         else
-          _326_ = 2
+          _334_ = 2
         end
-        target.beacon = {_326_, {shortcut_24}}
+        target.beacon = {_334_, {shortcut_24}}
       elseif shortcut_3f then
         if overlapped_3f then
           target.beacon = {1, {overlapped_shortcut_24}}
@@ -1433,7 +1464,7 @@ local function set_beacon(_315_, _repeat)
       else
         target.beacon = {2, {label_24}}
       end
-    elseif (_322_ == "active-secondary") then
+    elseif (_330_ == "active-secondary") then
       if to_eol_3f then
         if (vim.wo.wrap or ((col <= right_bound) and (col >= left_bound))) then
           target.beacon = {0, {distant_label_24}}
@@ -1445,13 +1476,13 @@ local function set_beacon(_315_, _repeat)
         target.beacon = nil
         end
       elseif _repeat then
-        local _332_
+        local _340_
         if squeezed_3f then
-          _332_ = 1
+          _340_ = 1
         else
-          _332_ = 2
+          _340_ = 2
         end
-        target.beacon = {_332_, {distant_label_24}}
+        target.beacon = {_340_, {distant_label_24}}
       elseif overlapped_3f then
         target.beacon = {1, {overlapped_distant_label_24}}
       elseif squeezed_3f then
@@ -1459,7 +1490,7 @@ local function set_beacon(_315_, _repeat)
       else
         target.beacon = {2, {distant_label_24}}
       end
-    elseif (_322_ == "inactive") then
+    elseif (_330_ == "inactive") then
       target.beacon = nil
     else
     target.beacon = nil
@@ -1467,9 +1498,9 @@ local function set_beacon(_315_, _repeat)
   end
   return nil
 end
-local function set_beacons(target_list, _336_)
-  local _arg_337_ = _336_
-  local _repeat = _arg_337_["repeat"]
+local function set_beacons(target_list, _344_)
+  local _arg_345_ = _344_
+  local _repeat = _arg_345_["repeat"]
   for _, target in ipairs(target_list) do
     set_beacon(target, _repeat)
   end
@@ -1477,34 +1508,34 @@ local function set_beacons(target_list, _336_)
 end
 local function light_up_beacons(target_list, _3fstart_idx)
   for i = (_3fstart_idx or 1), #target_list do
-    local _let_338_ = target_list[i]
-    local beacon = _let_338_["beacon"]
-    local _let_339_ = _let_338_["pos"]
-    local line = _let_339_[1]
-    local col = _let_339_[2]
-    local _340_ = beacon
-    if ((type(_340_) == "table") and (nil ~= (_340_)[1]) and (nil ~= (_340_)[2]) and true) then
-      local offset = (_340_)[1]
-      local chunks = (_340_)[2]
-      local _3fleft_off_3f = (_340_)[3]
-      local _341_
+    local _let_346_ = target_list[i]
+    local beacon = _let_346_["beacon"]
+    local _let_347_ = _let_346_["pos"]
+    local line = _let_347_[1]
+    local col = _let_347_[2]
+    local _348_ = beacon
+    if ((type(_348_) == "table") and (nil ~= (_348_)[1]) and (nil ~= (_348_)[2]) and true) then
+      local offset = (_348_)[1]
+      local chunks = (_348_)[2]
+      local _3fleft_off_3f = (_348_)[3]
+      local _349_
       if _3fleft_off_3f then
-        _341_ = 0
+        _349_ = 0
       else
-      _341_ = nil
+      _349_ = nil
       end
-      hl["set-extmark"](hl, dec(line), dec((col + offset)), {virt_text = chunks, virt_text_pos = "overlay", virt_text_win_col = _341_})
+      hl["set-extmark"](hl, dec(line), dec((col + offset)), {virt_text = chunks, virt_text_pos = "overlay", virt_text_win_col = _349_})
     end
   end
   return nil
 end
 local function get_target_with_active_primary_label(target_list, input)
   local res = nil
-  for _, _344_ in ipairs(target_list) do
-    local _each_345_ = _344_
-    local target = _each_345_
-    local label = _each_345_["label"]
-    local label_state = _each_345_["label-state"]
+  for _, _352_ in ipairs(target_list) do
+    local _each_353_ = _352_
+    local target = _each_353_
+    local label = _each_353_["label"]
+    local label_state = _each_353_["label-state"]
     if res then break end
     if ((label == input) and (label_state == "active-primary")) then
       res = target
@@ -1513,9 +1544,9 @@ local function get_target_with_active_primary_label(target_list, input)
   return res
 end
 local function ignore_input_until_timeout(char_to_ignore)
-  local _347_ = get_input(opts.jump_on_partial_input_safety_timeout)
-  if (nil ~= _347_) then
-    local input = _347_
+  local _355_ = get_input(opts.jump_on_partial_input_safety_timeout)
+  if (nil ~= _355_) then
+    local input = _355_
     if (input ~= char_to_ignore) then
       return vim.fn.feedkeys(input, "i")
     end
@@ -1540,14 +1571,14 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
   local invoked_as_reverse_3f = reverse_3f
   local reverse_3f0
   if cold_repeat_3f then
-    local function _351_(_241)
+    local function _359_(_241)
       if invoked_as_reverse_3f then
         return not _241
       else
         return _241
       end
     end
-    reverse_3f0 = _351_(self.state.cold["reverse?"])
+    reverse_3f0 = _359_(self.state.cold["reverse?"])
   else
     reverse_3f0 = reverse_3f
   end
@@ -1569,8 +1600,8 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     elseif cold_repeat_3f then
       return self.state.cold.in1
     else
-      local _355_
-      local function _356_()
+      local _363_
+      local function _364_()
         local res_2_auto
         do
           res_2_auto = get_input()
@@ -1578,7 +1609,7 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         hl:cleanup()
         return res_2_auto
       end
-      local function _357_()
+      local function _365_()
         if change_operation_3f() then
           handle_interrupted_change_op_21()
         end
@@ -1588,11 +1619,11 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         doau_when_exists("LightspeedLeave")
         return nil
       end
-      _355_ = (_356_() or _357_())
-      if (_355_ == _3cbackspace_3e) then
+      _363_ = (_364_() or _365_())
+      if (_363_ == _3cbackspace_3e) then
         backspace_repeat_3f = true
         new_search_3f = false
-        local function _359_()
+        local function _367_()
           if change_operation_3f() then
             handle_interrupted_change_op_21()
           end
@@ -1603,48 +1634,48 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
           doau_when_exists("LightspeedLeave")
           return nil
         end
-        return (self.state.cold.in1 or _359_())
-      elseif (nil ~= _355_) then
-        local _in = _355_
+        return (self.state.cold.in1 or _367_())
+      elseif (nil ~= _363_) then
+        local _in = _363_
         return _in
       end
     end
   end
   local function update_state_2a(in1)
-    local function _365_(_363_)
-      local _arg_364_ = _363_
-      local cold = _arg_364_["cold"]
-      local dot = _arg_364_["dot"]
+    local function _373_(_371_)
+      local _arg_372_ = _371_
+      local cold = _arg_372_["cold"]
+      local dot = _arg_372_["dot"]
       if new_search_3f then
         if cold then
-          local _366_ = cold
-          _366_["in1"] = in1
-          _366_["x-mode?"] = x_mode_3f0
-          _366_["reverse?"] = reverse_3f0
-          self.state.cold = _366_
+          local _374_ = cold
+          _374_["in1"] = in1
+          _374_["x-mode?"] = x_mode_3f0
+          _374_["reverse?"] = reverse_3f0
+          self.state.cold = _374_
         end
         if dot then
           if dot_repeatable_op_3f then
             do
-              local _368_ = dot
-              _368_["in1"] = in1
-              _368_["x-mode?"] = x_mode_3f0
-              self.state.dot = _368_
+              local _376_ = dot
+              _376_["in1"] = in1
+              _376_["x-mode?"] = x_mode_3f0
+              self.state.dot = _376_
             end
             return nil
           end
         end
       end
     end
-    return _365_
+    return _373_
   end
   local jump_to_21
   do
     local first_jump_3f = true
-    local function _372_(target, _3fto_pre_eol_3f)
+    local function _380_(target, _3fto_pre_eol_3f)
       local to_pre_eol_3f0 = (_3fto_pre_eol_3f or to_pre_eol_3f)
       local adjusted_pos
-      local function _373_()
+      local function _381_()
         if to_eol_3f then
           if op_mode_3f then
             return push_cursor_21("fwd")
@@ -1660,37 +1691,37 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
           end
         end
       end
-      adjusted_pos = jump_to_21_2a(target, {["add-to-jumplist?"] = (first_jump_3f and not instant_repeat_3f), ["inclusive-motion?"] = (x_mode_3f0 and not reverse_3f0), ["reverse?"] = reverse_3f0, adjust = _373_, mode = mode})
+      adjusted_pos = jump_to_21_2a(target, {["add-to-jumplist?"] = (first_jump_3f and not instant_repeat_3f), ["inclusive-motion?"] = (x_mode_3f0 and not reverse_3f0), ["reverse?"] = reverse_3f0, adjust = _381_, mode = mode})
       first_jump_3f = false
       return adjusted_pos
     end
-    jump_to_21 = _372_
+    jump_to_21 = _380_
   end
   local function highlight_new_curpos_and_op_area(from_pos, to_pos)
     local motion_force = get_motion_force(mode)
     local blockwise_3f = (motion_force == _3cctrl_v_3e)
-    local function _379_()
+    local function _387_()
       if reverse_3f0 then
         return to_pos
       else
         return from_pos
       end
     end
-    local _let_378_ = _379_()
-    local startline = _let_378_[1]
-    local startcol = _let_378_[2]
-    local start = _let_378_
-    local function _381_()
+    local _let_386_ = _387_()
+    local startline = _let_386_[1]
+    local startcol = _let_386_[2]
+    local start = _let_386_
+    local function _389_()
       if reverse_3f0 then
         return from_pos
       else
         return to_pos
       end
     end
-    local _let_380_ = _381_()
-    local _ = _let_380_[1]
-    local endcol = _let_380_[2]
-    local _end = _let_380_
+    local _let_388_ = _389_()
+    local _ = _let_388_[1]
+    local endcol = _let_388_[2]
+    local _end = _let_388_
     local top_left = {startline, min(startcol, endcol)}
     local new_curpos
     if op_mode_3f then
@@ -1711,15 +1742,15 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     return vim.cmd("redraw")
   end
   local function get_sublist(targets, ch)
-    local _386_ = targets.sublists[ch]
-    if (nil ~= _386_) then
-      local sublist = _386_
-      local _let_387_ = sublist
-      local _let_388_ = _let_387_[1]
-      local _let_389_ = _let_388_["pos"]
-      local line = _let_389_[1]
-      local col = _let_389_[2]
-      local rest = {(table.unpack or unpack)(_let_387_, 2)}
+    local _394_ = targets.sublists[ch]
+    if (nil ~= _394_) then
+      local sublist = _394_
+      local _let_395_ = sublist
+      local _let_396_ = _let_395_[1]
+      local _let_397_ = _let_396_["pos"]
+      local line = _let_397_[1]
+      local col = _let_397_[2]
+      local rest = {(table.unpack or unpack)(_let_395_, 2)}
       local target_tail = {line, inc(col)}
       local prev_pos = vim.fn.searchpos("\\_.", "nWb")
       local cursor_touches_first_target_3f = same_pos_3f(target_tail, prev_pos)
@@ -1736,15 +1767,15 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     local next_group_key = replace_keycodes(opts.cycle_group_fwd_key)
     local prev_group_key = replace_keycodes(opts.cycle_group_bwd_key)
     local function recur(group_offset, initial_invoc_3f)
-      local _393_
+      local _401_
       if (cold_repeat_3f or backspace_repeat_3f) then
-        _393_ = "cold"
+        _401_ = "cold"
       elseif instant_repeat_3f then
-        _393_ = "instant"
+        _401_ = "instant"
       else
-      _393_ = nil
+      _401_ = nil
       end
-      set_beacons(sublist, {["repeat"] = _393_})
+      set_beacons(sublist, {["repeat"] = _401_})
       do
         if (opts.grey_out_search_area and not (cold_repeat_3f or instant_repeat_3f or to_eol_3f)) then
           grey_out_search_area(reverse_3f0)
@@ -1755,22 +1786,22 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         highlight_cursor()
         vim.cmd("redraw")
       end
-      local _396_
+      local _404_
       do
         local res_2_auto
         do
-          local function _397_()
+          local function _405_()
             if initial_invoc_3f then
               return opts.exit_after_idle_msecs.labeled
             end
           end
-          res_2_auto = get_input(_397_())
+          res_2_auto = get_input(_405_())
         end
         hl:cleanup()
-        _396_ = res_2_auto
+        _404_ = res_2_auto
       end
-      if (nil ~= _396_) then
-        local input = _396_
+      if (nil ~= _404_) then
+        local input = _404_
         if (sublist["autojump?"] and opts.labels and not empty_3f(opts.labels)) then
           return {input, 0}
         elseif (((input == next_group_key) or (input == prev_group_key)) and not instant_repeat_3f) then
@@ -1778,17 +1809,17 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
           local num_of_groups = ceil((#sublist / #labels))
           local max_offset = dec(num_of_groups)
           local group_offset_2a
-          local _399_
+          local _407_
           do
-            local _398_ = input
-            if (_398_ == next_group_key) then
-              _399_ = inc
+            local _406_ = input
+            if (_406_ == next_group_key) then
+              _407_ = inc
             else
-              local _ = _398_
-              _399_ = dec
+              local _ = _406_
+              _407_ = dec
             end
           end
-          group_offset_2a = clamp(_399_(group_offset), 0, max_offset)
+          group_offset_2a = clamp(_407_(group_offset), 0, max_offset)
           set_label_states_for_sublist(sublist, {["group-offset"] = group_offset_2a})
           return recur(group_offset_2a)
         else
@@ -1812,9 +1843,9 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     highlight_cursor()
     vim.cmd("redraw")
   end
-  local _408_ = get_first_input()
-  if (nil ~= _408_) then
-    local in1 = _408_
+  local _416_ = get_first_input()
+  if (nil ~= _416_) then
+    local in1 = _416_
     local _
     to_eol_3f = (in1 == "\13")
     _ = nil
@@ -1830,15 +1861,15 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     else
     prev_in2 = nil
     end
-    local _410_
-    local function _412_()
-      local t_411_ = instant_state
-      if (nil ~= t_411_) then
-        t_411_ = (t_411_).sublist
+    local _418_
+    local function _420_()
+      local t_419_ = instant_state
+      if (nil ~= t_419_) then
+        t_419_ = (t_419_).sublist
       end
-      return t_411_
+      return t_419_
     end
-    local function _414_()
+    local function _422_()
       if change_operation_3f() then
         handle_interrupted_change_op_21()
       end
@@ -1849,11 +1880,11 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
       doau_when_exists("LightspeedLeave")
       return nil
     end
-    _410_ = (_412_() or get_targets(in1, reverse_3f0) or _414_())
-    if ((type(_410_) == "table") and ((type((_410_)[1]) == "table") and ((type(((_410_)[1]).pair) == "table") and true and (nil ~= (((_410_)[1]).pair)[2]))) and ((_410_)[2] == nil)) then
-      local _0 = (((_410_)[1]).pair)[1]
-      local ch2 = (((_410_)[1]).pair)[2]
-      local only = (_410_)[1]
+    _418_ = (_420_() or get_targets(in1, reverse_3f0) or _422_())
+    if ((type(_418_) == "table") and ((type((_418_)[1]) == "table") and ((type(((_418_)[1]).pair) == "table") and true and (nil ~= (((_418_)[1]).pair)[2]))) and ((_418_)[2] == nil)) then
+      local _0 = (((_418_)[1]).pair)[1]
+      local ch2 = (((_418_)[1]).pair)[2]
+      local only = (_418_)[1]
       if (new_search_3f or (ch2 == prev_in2)) then
         do
           if dot_repeatable_op_3f then
@@ -1884,19 +1915,19 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         doau_when_exists("LightspeedLeave")
         return nil
       end
-    elseif (nil ~= _410_) then
-      local targets = _410_
+    elseif (nil ~= _418_) then
+      local targets = _418_
       if not instant_repeat_3f then
-        local _420_ = targets
-        populate_sublists(_420_)
-        set_labels(_420_, to_eol_3f)
-        set_label_states(_420_)
+        local _428_ = targets
+        populate_sublists(_428_)
+        set_labels(_428_, to_eol_3f)
+        set_label_states(_428_)
       end
       if (new_search_3f and not to_eol_3f) then
         do
-          local _422_ = targets
-          set_shortcuts_and_populate_shortcuts_map(_422_)
-          set_beacons(_422_, {["repeat"] = nil})
+          local _430_ = targets
+          set_shortcuts_and_populate_shortcuts_map(_430_)
+          set_beacons(_430_, {["repeat"] = nil})
         end
         if (opts.grey_out_search_area and not (cold_repeat_3f or instant_repeat_3f or to_eol_3f)) then
           grey_out_search_area(reverse_3f0)
@@ -1907,13 +1938,13 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         highlight_cursor()
         vim.cmd("redraw")
       end
-      local _425_
-      local function _426_()
+      local _433_
+      local function _434_()
         if to_eol_3f then
           return ""
         end
       end
-      local function _427_()
+      local function _435_()
         local res_2_auto
         do
           res_2_auto = get_input()
@@ -1921,7 +1952,7 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         hl:cleanup()
         return res_2_auto
       end
-      local function _428_()
+      local function _436_()
         if change_operation_3f() then
           handle_interrupted_change_op_21()
         end
@@ -1931,21 +1962,21 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         doau_when_exists("LightspeedLeave")
         return nil
       end
-      _425_ = (prev_in2 or _426_() or _427_() or _428_())
-      if (nil ~= _425_) then
-        local in2 = _425_
-        local _430_
+      _433_ = (prev_in2 or _434_() or _435_() or _436_())
+      if (nil ~= _433_) then
+        local in2 = _433_
+        local _438_
         do
-          local t_431_ = targets.shortcuts
-          if (nil ~= t_431_) then
-            t_431_ = (t_431_)[in2]
+          local t_439_ = targets.shortcuts
+          if (nil ~= t_439_) then
+            t_439_ = (t_439_)[in2]
           end
-          _430_ = t_431_
+          _438_ = t_439_
         end
-        if ((type(_430_) == "table") and ((type((_430_).pair) == "table") and true and (nil ~= ((_430_).pair)[2]))) then
-          local _0 = ((_430_).pair)[1]
-          local ch2 = ((_430_).pair)[2]
-          local shortcut = _430_
+        if ((type(_438_) == "table") and ((type((_438_).pair) == "table") and true and (nil ~= ((_438_).pair)[2]))) then
+          local _0 = ((_438_).pair)[1]
+          local ch2 = ((_438_).pair)[2]
+          local shortcut = _438_
           do
             if dot_repeatable_op_3f then
               set_dot_repeat(replace_keycodes(get_plug_key("sx", reverse_3f0, x_mode_3f0, "dot")))
@@ -1957,18 +1988,18 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
           doau_when_exists("LightspeedLeave")
           return nil
         else
-          local _0 = _430_
+          local _0 = _438_
           to_pre_eol_3f = (in2 == "\13")
           update_state({cold = {in2 = in2}})
-          local _434_
-          local function _436_()
-            local t_435_ = instant_state
-            if (nil ~= t_435_) then
-              t_435_ = (t_435_).sublist
+          local _442_
+          local function _444_()
+            local t_443_ = instant_state
+            if (nil ~= t_443_) then
+              t_443_ = (t_443_).sublist
             end
-            return t_435_
+            return t_443_
           end
-          local function _438_()
+          local function _446_()
             if change_operation_3f() then
               handle_interrupted_change_op_21()
             end
@@ -1979,9 +2010,9 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
             doau_when_exists("LightspeedLeave")
             return nil
           end
-          _434_ = (_436_() or get_sublist(targets, in2) or _438_())
-          if ((type(_434_) == "table") and (nil ~= (_434_)[1]) and ((_434_)[2] == nil)) then
-            local only = (_434_)[1]
+          _442_ = (_444_() or get_sublist(targets, in2) or _446_())
+          if ((type(_442_) == "table") and (nil ~= (_442_)[1]) and ((_442_)[2] == nil)) then
+            local only = (_442_)[1]
             do
               if dot_repeatable_op_3f then
                 set_dot_repeat(replace_keycodes(get_plug_key("sx", reverse_3f0, x_mode_3f0, "dot")))
@@ -1992,26 +2023,26 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
             doau_when_exists("LightspeedSxLeave")
             doau_when_exists("LightspeedLeave")
             return nil
-          elseif ((type(_434_) == "table") and (nil ~= (_434_)[1])) then
-            local first = (_434_)[1]
-            local sublist = _434_
+          elseif ((type(_442_) == "table") and (nil ~= (_442_)[1])) then
+            local first = (_442_)[1]
+            local sublist = _442_
             local autojump_3f = sublist["autojump?"]
             local curr_idx
-            local function _442_()
-              local t_441_ = instant_state
-              if (nil ~= t_441_) then
-                t_441_ = (t_441_).idx
+            local function _450_()
+              local t_449_ = instant_state
+              if (nil ~= t_449_) then
+                t_449_ = (t_449_).idx
               end
-              return t_441_
+              return t_449_
             end
-            local function _444_()
+            local function _452_()
               if autojump_3f then
                 return 1
               else
                 return 0
               end
             end
-            curr_idx = (_442_() or _444_())
+            curr_idx = (_450_() or _452_())
             local from_reverse_cold_repeat_3f
             if instant_repeat_3f then
               from_reverse_cold_repeat_3f = instant_state["from-reverse-cold-repeat?"]
@@ -2021,13 +2052,13 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
             if (autojump_3f and not instant_repeat_3f) then
               jump_to_21(first.pos)
             end
-            local _447_
-            local function _448_()
+            local _455_
+            local function _456_()
               if (dot_repeat_3f and self.state.dot.in3) then
                 return {self.state.dot.in3, 0}
               end
             end
-            local function _449_()
+            local function _457_()
               if change_operation_3f() then
                 handle_interrupted_change_op_21()
               end
@@ -2037,24 +2068,24 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
               doau_when_exists("LightspeedLeave")
               return nil
             end
-            _447_ = (_448_() or get_last_input(sublist, inc(curr_idx)) or _449_())
-            if ((type(_447_) == "table") and (nil ~= (_447_)[1]) and (nil ~= (_447_)[2])) then
-              local in3 = (_447_)[1]
-              local group_offset = (_447_)[2]
-              local _451_
+            _455_ = (_456_() or get_last_input(sublist, inc(curr_idx)) or _457_())
+            if ((type(_455_) == "table") and (nil ~= (_455_)[1]) and (nil ~= (_455_)[2])) then
+              local in3 = (_455_)[1]
+              local group_offset = (_455_)[2]
+              local _459_
               if not (op_mode_3f or (group_offset > 0)) then
-                _451_ = get_repeat_action(in3, "sx", x_mode_3f0, instant_repeat_3f, from_reverse_cold_repeat_3f)
+                _459_ = get_repeat_action(in3, "sx", x_mode_3f0, instant_repeat_3f, from_reverse_cold_repeat_3f)
               else
-              _451_ = nil
+              _459_ = nil
               end
-              if (nil ~= _451_) then
-                local action = _451_
+              if (nil ~= _459_) then
+                local action = _459_
                 local idx
                 do
-                  local _453_ = action
-                  if (_453_ == "repeat") then
+                  local _461_ = action
+                  if (_461_ == "repeat") then
                     idx = min(inc(curr_idx), #targets)
-                  elseif (_453_ == "revert") then
+                  elseif (_461_ == "revert") then
                     idx = max(dec(curr_idx), 1)
                   else
                   idx = nil
@@ -2063,28 +2094,28 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
                 jump_to_21(sublist[idx].pos)
                 return sx:go(reverse_3f0, x_mode_3f0, {["from-reverse-cold-repeat?"] = from_reverse_cold_repeat_3f, idx = idx, in1 = in1, in2 = in2, sublist = sublist})
               else
-                local _1 = _451_
-                local _455_ = get_target_with_active_primary_label(sublist, in3)
-                if (nil ~= _455_) then
-                  local target = _455_
+                local _1 = _459_
+                local _463_ = get_target_with_active_primary_label(sublist, in3)
+                if (nil ~= _463_) then
+                  local target = _463_
                   do
                     if dot_repeatable_op_3f then
                       set_dot_repeat(replace_keycodes(get_plug_key("sx", reverse_3f0, x_mode_3f0, "dot")))
                     end
-                    local _457_
+                    local _465_
                     if (group_offset > 0) then
-                      _457_ = nil
+                      _465_ = nil
                     else
-                      _457_ = in3
+                      _465_ = in3
                     end
-                    update_state({dot = {in2 = in2, in3 = _457_}})
+                    update_state({dot = {in2 = in2, in3 = _465_}})
                     jump_to_21(target.pos)
                   end
                   doau_when_exists("LightspeedSxLeave")
                   doau_when_exists("LightspeedLeave")
                   return nil
                 else
-                  local _2 = _455_
+                  local _2 = _463_
                   if autojump_3f then
                     do
                       if dot_repeatable_op_3f then
@@ -2118,26 +2149,26 @@ local temporary_editor_opts = {["vim.bo.modeline"] = false, ["vim.wo.concealleve
 local saved_editor_opts = {}
 local function save_editor_opts()
   for opt, _ in pairs(temporary_editor_opts) do
-    local _let_470_ = vim.split(opt, ".", true)
-    local _0 = _let_470_[1]
-    local scope = _let_470_[2]
-    local name = _let_470_[3]
-    local _471_
+    local _let_478_ = vim.split(opt, ".", true)
+    local _0 = _let_478_[1]
+    local scope = _let_478_[2]
+    local name = _let_478_[3]
+    local _479_
     if (opt == "vim.wo.scrolloff") then
-      _471_ = api.nvim_eval("&l:scrolloff")
+      _479_ = api.nvim_eval("&l:scrolloff")
     else
-      _471_ = _G.vim[scope][name]
+      _479_ = _G.vim[scope][name]
     end
-    saved_editor_opts[opt] = _471_
+    saved_editor_opts[opt] = _479_
   end
   return nil
 end
 local function set_editor_opts(opts0)
   for opt, val in pairs(opts0) do
-    local _let_473_ = vim.split(opt, ".", true)
-    local _ = _let_473_[1]
-    local scope = _let_473_[2]
-    local name = _let_473_[3]
+    local _let_481_ = vim.split(opt, ".", true)
+    local _ = _let_481_[1]
+    local scope = _let_481_[2]
+    local name = _let_481_[3]
     _G.vim[scope][name] = val
   end
   return nil
@@ -2150,29 +2181,29 @@ local function restore_editor_opts()
 end
 local function set_plug_keys()
   local plug_keys = {{"<Plug>Lightspeed_s", "sx:go(false)"}, {"<Plug>Lightspeed_S", "sx:go(true)"}, {"<Plug>Lightspeed_x", "sx:go(false, true)"}, {"<Plug>Lightspeed_X", "sx:go(true, true)"}, {"<Plug>Lightspeed_f", "ft:go(false)"}, {"<Plug>Lightspeed_F", "ft:go(true)"}, {"<Plug>Lightspeed_t", "ft:go(false, true)"}, {"<Plug>Lightspeed_T", "ft:go(true, true)"}, {"<Plug>Lightspeed_;_sx", "sx:go(false, nil, 'cold')"}, {"<Plug>Lightspeed_,_sx", "sx:go(true, nil, 'cold')"}, {"<Plug>Lightspeed_;_ft", "ft:go(false, nil, 'cold')"}, {"<Plug>Lightspeed_,_ft", "ft:go(true, nil, 'cold')"}}
-  for _, _474_ in ipairs(plug_keys) do
-    local _each_475_ = _474_
-    local lhs = _each_475_[1]
-    local rhs_call = _each_475_[2]
+  for _, _482_ in ipairs(plug_keys) do
+    local _each_483_ = _482_
+    local lhs = _each_483_[1]
+    local rhs_call = _each_483_[2]
     for _0, mode in ipairs({"n", "x", "o"}) do
       api.nvim_set_keymap(mode, lhs, ("<cmd>lua require'lightspeed'." .. rhs_call .. "<cr>"), {noremap = true, silent = true})
     end
   end
-  for _, _476_ in ipairs({{"<Plug>Lightspeed_dotrepeat_s", "sx:go(false, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_S", "sx:go(true, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_x", "sx:go(false, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_X", "sx:go(true, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_f", "ft:go(false, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_F", "ft:go(true, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_t", "ft:go(false, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_T", "ft:go(true, true, 'dot')"}}) do
-    local _each_477_ = _476_
-    local lhs = _each_477_[1]
-    local rhs_call = _each_477_[2]
+  for _, _484_ in ipairs({{"<Plug>Lightspeed_dotrepeat_s", "sx:go(false, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_S", "sx:go(true, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_x", "sx:go(false, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_X", "sx:go(true, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_f", "ft:go(false, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_F", "ft:go(true, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_t", "ft:go(false, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_T", "ft:go(true, true, 'dot')"}}) do
+    local _each_485_ = _484_
+    local lhs = _each_485_[1]
+    local rhs_call = _each_485_[2]
     api.nvim_set_keymap("o", lhs, ("<cmd>lua require'lightspeed'." .. rhs_call .. "<cr>"), {noremap = true, silent = true})
   end
   return nil
 end
 local function set_default_keymaps()
   local default_keymaps = {{"n", "s", "<Plug>Lightspeed_s"}, {"n", "S", "<Plug>Lightspeed_S"}, {"x", "s", "<Plug>Lightspeed_s"}, {"x", "S", "<Plug>Lightspeed_S"}, {"o", "z", "<Plug>Lightspeed_s"}, {"o", "Z", "<Plug>Lightspeed_S"}, {"o", "x", "<Plug>Lightspeed_x"}, {"o", "X", "<Plug>Lightspeed_X"}, {"n", "f", "<Plug>Lightspeed_f"}, {"n", "F", "<Plug>Lightspeed_F"}, {"x", "f", "<Plug>Lightspeed_f"}, {"x", "F", "<Plug>Lightspeed_F"}, {"o", "f", "<Plug>Lightspeed_f"}, {"o", "F", "<Plug>Lightspeed_F"}, {"n", "t", "<Plug>Lightspeed_t"}, {"n", "T", "<Plug>Lightspeed_T"}, {"x", "t", "<Plug>Lightspeed_t"}, {"x", "T", "<Plug>Lightspeed_T"}, {"o", "t", "<Plug>Lightspeed_t"}, {"o", "T", "<Plug>Lightspeed_T"}, {"n", ";", "<Plug>Lightspeed_;_ft"}, {"x", ";", "<Plug>Lightspeed_;_ft"}, {"o", ";", "<Plug>Lightspeed_;_ft"}, {"n", ",", "<Plug>Lightspeed_,_ft"}, {"x", ",", "<Plug>Lightspeed_,_ft"}, {"o", ",", "<Plug>Lightspeed_,_ft"}}
-  for _, _478_ in ipairs(default_keymaps) do
-    local _each_479_ = _478_
-    local mode = _each_479_[1]
-    local lhs = _each_479_[2]
-    local rhs = _each_479_[3]
+  for _, _486_ in ipairs(default_keymaps) do
+    local _each_487_ = _486_
+    local mode = _each_487_[1]
+    local lhs = _each_487_[2]
+    local rhs = _each_487_[3]
     if ((vim.fn.mapcheck(lhs, mode) == "") and (vim.fn.hasmapto(rhs, mode) == 0)) then
       api.nvim_set_keymap(mode, lhs, rhs, {silent = true})
     end

--- a/lua/lightspeed.lua
+++ b/lua/lightspeed.lua
@@ -127,7 +127,7 @@ local opts
 do
   local safe_labels = {"s", "f", "n", "u", "t", "/", "F", "L", "N", "H", "G", "M", "U", "T", "?", "Z"}
   local labels = {"s", "f", "n", "j", "k", "l", "o", "i", "w", "e", "h", "g", "u", "t", "m", "v", "c", "a", ".", "z", "/", "F", "L", "N", "H", "G", "M", "U", "T", "?", "Z"}
-  opts = {ignore_case = false, exit_after_idle_msecs = {labeled = nil, unlabeled = 1000}, ["disable-default-mappings"] = true, grey_out_search_area = true, highlight_unique_chars = true, match_only_the_start_of_same_char_seqs = true, jump_on_partial_input_safety_timeout = 400, substitute_chars = {["\13"] = "\194\172"}, safe_labels = safe_labels, labels = labels, cycle_group_fwd_key = "<space>", cycle_group_bwd_key = "<tab>", limit_ft_matches = 4, repeat_ft_with_target_char = false}
+  opts = {ignore_case = false, exit_after_idle_msecs = {labeled = nil, unlabeled = 1000}, override_x = true, override_s = true, override_motion = true, grey_out_search_area = true, highlight_unique_chars = true, match_only_the_start_of_same_char_seqs = true, jump_on_partial_input_safety_timeout = 400, substitute_chars = {["\13"] = "\194\172"}, safe_labels = safe_labels, labels = labels, cycle_group_fwd_key = "<space>", cycle_group_bwd_key = "<tab>", limit_ft_matches = 4, repeat_ft_with_target_char = false}
 end
 local deprecated_opts = {"jump_to_first_match", "instant_repeat_fwd_key", "instant_repeat_bwd_key", "x_mode_prefix_key", "full_inclusive_prefix_key"}
 local function get_deprec_msg(arg_fields)
@@ -192,72 +192,97 @@ local function normalize_opts(opts0)
   end
   return opts0
 end
-local function setup(user_opts)
-  if not ("disable-default-mappings")(user_opts) then
-    __fnl_global__set_2ddefault_2dkeymaps()
-  else
+local function set_plug_keys()
+  local plug_keys = {{"<Plug>Lightspeed_s", "sx:go(false)"}, {"<Plug>Lightspeed_S", "sx:go(true)"}, {"<Plug>Lightspeed_x", "sx:go(false, true)"}, {"<Plug>Lightspeed_X", "sx:go(true, true)"}, {"<Plug>Lightspeed_f", "ft:go(false)"}, {"<Plug>Lightspeed_F", "ft:go(true)"}, {"<Plug>Lightspeed_t", "ft:go(false, true)"}, {"<Plug>Lightspeed_T", "ft:go(true, true)"}, {"<Plug>Lightspeed_;_sx", "sx:go(false, nil, 'cold')"}, {"<Plug>Lightspeed_,_sx", "sx:go(true, nil, 'cold')"}, {"<Plug>Lightspeed_;_ft", "ft:go(false, nil, 'cold')"}, {"<Plug>Lightspeed_,_ft", "ft:go(true, nil, 'cold')"}}
+  for _, _27_ in ipairs(plug_keys) do
+    local _each_28_ = _27_
+    local lhs = _each_28_[1]
+    local rhs_call = _each_28_[2]
+    for _0, mode in ipairs({"n", "x", "o"}) do
+      api.nvim_set_keymap(mode, lhs, ("<cmd>lua require'lightspeed'." .. rhs_call .. "<cr>"), {noremap = true, silent = true})
+    end
   end
-  opts = setmetatable(normalize_opts(user_opts), {__index = opts})
+  for _, _29_ in ipairs({{"<Plug>Lightspeed_dotrepeat_s", "sx:go(false, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_S", "sx:go(true, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_x", "sx:go(false, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_X", "sx:go(true, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_f", "ft:go(false, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_F", "ft:go(true, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_t", "ft:go(false, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_T", "ft:go(true, true, 'dot')"}}) do
+    local _each_30_ = _29_
+    local lhs = _each_30_[1]
+    local rhs_call = _each_30_[2]
+    api.nvim_set_keymap("o", lhs, ("<cmd>lua require'lightspeed'." .. rhs_call .. "<cr>"), {noremap = true, silent = true})
+  end
   return nil
 end
+local function set_default_keymaps()
+  local default_keymaps = {{"n", "f", "<Plug>Lightspeed_f"}, {"n", "F", "<Plug>Lightspeed_F"}, {"x", "f", "<Plug>Lightspeed_f"}, {"x", "F", "<Plug>Lightspeed_F"}, {"o", "f", "<Plug>Lightspeed_f"}, {"o", "F", "<Plug>Lightspeed_F"}, {"n", "t", "<Plug>Lightspeed_t"}, {"n", "T", "<Plug>Lightspeed_T"}, {"x", "t", "<Plug>Lightspeed_t"}, {"x", "T", "<Plug>Lightspeed_T"}, {"o", "t", "<Plug>Lightspeed_t"}, {"o", "T", "<Plug>Lightspeed_T"}, {"n", ";", "<Plug>Lightspeed_;_ft"}, {"x", ";", "<Plug>Lightspeed_;_ft"}, {"o", ";", "<Plug>Lightspeed_;_ft"}, {"n", ",", "<Plug>Lightspeed_,_ft"}, {"x", ",", "<Plug>Lightspeed_,_ft"}, {"o", ",", "<Plug>Lightspeed_,_ft"}}
+  local override_x_keymaps = {{"o", "x", "<Plug>Lightspeed_x"}, {"o", "X", "<Plug>Lightspeed_X"}}
+  local override_s_keymaps = {{"n", "s", "<Plug>Lightspeed_s"}, {"n", "S", "<Plug>Lightspeed_S"}, {"x", "s", "<Plug>Lightspeed_s"}, {"x", "S", "<Plug>Lightspeed_S"}, {"o", "z", "<Plug>Lightspeed_s"}, {"o", "Z", "<Plug>Lightspeed_S"}}
+  if opts.override_motion then
+    for _, _31_ in ipairs(default_keymaps) do
+      local _each_32_ = _31_
+      local mode = _each_32_[1]
+      local lhs = _each_32_[2]
+      local rhs = _each_32_[3]
+      if ((vim.fn.mapcheck(lhs, mode) == "") and (vim.fn.hasmapto(rhs, mode) == 0)) then
+        api.nvim_set_keymap(mode, lhs, rhs, {silent = true})
+      else
+      end
+    end
+  else
+  end
+  if opts.override_x then
+    for _, _35_ in ipairs(override_x_keymaps) do
+      local _each_36_ = _35_
+      local mode = _each_36_[1]
+      local lhs = _each_36_[2]
+      local rhs = _each_36_[3]
+      if ((vim.fn.mapcheck(lhs, mode) == "") and (vim.fn.hasmapto(rhs, mode) == 0)) then
+        api.nvim_set_keymap(mode, lhs, rhs)
+      else
+      end
+    end
+  else
+  end
+  if opts.override_s then
+    for _, _39_ in ipairs(override_s_keymaps) do
+      local _each_40_ = _39_
+      local mode = _each_40_[1]
+      local lhs = _each_40_[2]
+      local rhs = _each_40_[3]
+      if ((vim.fn.mapcheck(lhs, mode) == "") and (vim.fn.hasmapto(rhs, mode) == 0)) then
+        api.nvim_set_keymap(mode, lhs, rhs, {silent = true})
+      else
+      end
+    end
+    return nil
+  else
+    return nil
+  end
+end
+local function setup(user_opts)
+  opts = setmetatable(normalize_opts(user_opts), {__index = opts})
+  set_plug_keys()
+  return set_default_keymaps()
+end
 local hl
-local function _28_(self, hl_group, line, startcol, endcol)
+local function _43_(self, hl_group, line, startcol, endcol)
   return api.nvim_buf_add_highlight(0, self.ns, hl_group, line, startcol, endcol)
 end
-local function _29_(self, line, col, opts0)
+local function _44_(self, line, col, opts0)
   return api.nvim_buf_set_extmark(0, self.ns, line, col, opts0)
 end
-local function _30_(self)
+local function _45_(self)
   return api.nvim_buf_clear_namespace(0, self.ns, 0, -1)
 end
-hl = {group = {label = "LightspeedLabel", ["label-distant"] = "LightspeedLabelDistant", ["label-overlapped"] = "LightspeedLabelOverlapped", ["label-distant-overlapped"] = "LightspeedLabelDistantOverlapped", shortcut = "LightspeedShortcut", ["shortcut-overlapped"] = "LightspeedShortcutOverlapped", ["masked-ch"] = "LightspeedMaskedChar", ["unlabeled-match"] = "LightspeedUnlabeledMatch", ["one-char-match"] = "LightspeedOneCharMatch", ["unique-ch"] = "LightspeedUniqueChar", ["pending-op-area"] = "LightspeedPendingOpArea", greywash = "LightspeedGreyWash", cursor = "LightspeedCursor"}, ns = api.nvim_create_namespace(""), ["add-hl"] = _28_, ["set-extmark"] = _29_, cleanup = _30_}
+hl = {group = {label = "LightspeedLabel", ["label-distant"] = "LightspeedLabelDistant", ["label-overlapped"] = "LightspeedLabelOverlapped", ["label-distant-overlapped"] = "LightspeedLabelDistantOverlapped", shortcut = "LightspeedShortcut", ["shortcut-overlapped"] = "LightspeedShortcutOverlapped", ["masked-ch"] = "LightspeedMaskedChar", ["unlabeled-match"] = "LightspeedUnlabeledMatch", ["one-char-match"] = "LightspeedOneCharMatch", ["unique-ch"] = "LightspeedUniqueChar", ["pending-op-area"] = "LightspeedPendingOpArea", greywash = "LightspeedGreyWash", cursor = "LightspeedCursor"}, ns = api.nvim_create_namespace(""), ["add-hl"] = _43_, ["set-extmark"] = _44_, cleanup = _45_}
 local function init_highlight(force_3f)
   local bg = vim.o.background
   local groupdefs
-  local _32_
-  do
-    local _31_ = bg
-    if (_31_ == "light") then
-      _32_ = "#f02077"
-    elseif true then
-      local _ = _31_
-      _32_ = "#ff2f87"
-    else
-      _32_ = nil
-    end
-  end
-  local _37_
-  do
-    local _36_ = bg
-    if (_36_ == "light") then
-      _37_ = "#ff4090"
-    elseif true then
-      local _ = _36_
-      _37_ = "#e01067"
-    else
-      _37_ = nil
-    end
-  end
-  local _42_
-  do
-    local _41_ = bg
-    if (_41_ == "light") then
-      _42_ = "#399d9f"
-    elseif true then
-      local _ = _41_
-      _42_ = "#99ddff"
-    else
-      _42_ = nil
-    end
-  end
   local _47_
   do
     local _46_ = bg
     if (_46_ == "light") then
-      _47_ = "Blue"
+      _47_ = "#f02077"
     elseif true then
       local _ = _46_
-      _47_ = "Cyan"
+      _47_ = "#ff2f87"
     else
       _47_ = nil
     end
@@ -266,10 +291,10 @@ local function init_highlight(force_3f)
   do
     local _51_ = bg
     if (_51_ == "light") then
-      _52_ = "#59bdbf"
+      _52_ = "#ff4090"
     elseif true then
       local _ = _51_
-      _52_ = "#79bddf"
+      _52_ = "#e01067"
     else
       _52_ = nil
     end
@@ -278,10 +303,10 @@ local function init_highlight(force_3f)
   do
     local _56_ = bg
     if (_56_ == "light") then
-      _57_ = "Cyan"
+      _57_ = "#399d9f"
     elseif true then
       local _ = _56_
-      _57_ = "Blue"
+      _57_ = "#99ddff"
     else
       _57_ = nil
     end
@@ -290,10 +315,10 @@ local function init_highlight(force_3f)
   do
     local _61_ = bg
     if (_61_ == "light") then
-      _62_ = "#cc9999"
+      _62_ = "Blue"
     elseif true then
       local _ = _61_
-      _62_ = "#b38080"
+      _62_ = "Cyan"
     else
       _62_ = nil
     end
@@ -302,10 +327,10 @@ local function init_highlight(force_3f)
   do
     local _66_ = bg
     if (_66_ == "light") then
-      _67_ = "#272020"
+      _67_ = "#59bdbf"
     elseif true then
       local _ = _66_
-      _67_ = "#f3ecec"
+      _67_ = "#79bddf"
     else
       _67_ = nil
     end
@@ -314,21 +339,57 @@ local function init_highlight(force_3f)
   do
     local _71_ = bg
     if (_71_ == "light") then
-      _72_ = "Black"
+      _72_ = "Cyan"
     elseif true then
       local _ = _71_
-      _72_ = "White"
+      _72_ = "Blue"
     else
       _72_ = nil
     end
   end
-  groupdefs = {{hl.group.label, {guifg = _32_, ctermfg = "Red", guibg = "NONE", ctermbg = "NONE", gui = "bold,underline", cterm = "bold,underline"}}, {hl.group["label-overlapped"], {guifg = _37_, ctermfg = "Magenta", guibg = "NONE", ctermbg = "NONE", gui = "underline", cterm = "underline"}}, {hl.group["label-distant"], {guifg = _42_, ctermfg = _47_, guibg = "NONE", ctermbg = "NONE", gui = "bold,underline", cterm = "bold,underline"}}, {hl.group["label-distant-overlapped"], {guifg = _52_, ctermfg = _57_, gui = "underline", cterm = "underline"}}, {hl.group.shortcut, {guibg = "#f00077", ctermbg = "Red", guifg = "#ffffff", ctermfg = "White", gui = "bold,underline", cterm = "bold,underline"}}, {hl.group["one-char-match"], {guibg = "#f00077", ctermbg = "Red", guifg = "#ffffff", ctermfg = "White", gui = "bold", cterm = "bold"}}, {hl.group["masked-ch"], {guifg = _62_, ctermfg = "DarkGrey", guibg = "NONE", ctermbg = "NONE", gui = "NONE", cterm = "NONE"}}, {hl.group["unlabeled-match"], {guifg = _67_, ctermfg = _72_, guibg = "NONE", ctermbg = "NONE", gui = "bold", cterm = "bold"}}, {hl.group["pending-op-area"], {guibg = "#f00077", ctermbg = "Red", guifg = "#ffffff", ctermfg = "White"}}, {hl.group.greywash, {guifg = "#777777", ctermfg = "Grey", guibg = "NONE", ctermbg = "NONE", gui = "NONE", cterm = "NONE"}}}
-  for _, _76_ in ipairs(groupdefs) do
-    local _each_77_ = _76_
-    local group = _each_77_[1]
-    local attrs = _each_77_[2]
+  local _77_
+  do
+    local _76_ = bg
+    if (_76_ == "light") then
+      _77_ = "#cc9999"
+    elseif true then
+      local _ = _76_
+      _77_ = "#b38080"
+    else
+      _77_ = nil
+    end
+  end
+  local _82_
+  do
+    local _81_ = bg
+    if (_81_ == "light") then
+      _82_ = "#272020"
+    elseif true then
+      local _ = _81_
+      _82_ = "#f3ecec"
+    else
+      _82_ = nil
+    end
+  end
+  local _87_
+  do
+    local _86_ = bg
+    if (_86_ == "light") then
+      _87_ = "Black"
+    elseif true then
+      local _ = _86_
+      _87_ = "White"
+    else
+      _87_ = nil
+    end
+  end
+  groupdefs = {{hl.group.label, {guifg = _47_, ctermfg = "Red", guibg = "NONE", ctermbg = "NONE", gui = "bold,underline", cterm = "bold,underline"}}, {hl.group["label-overlapped"], {guifg = _52_, ctermfg = "Magenta", guibg = "NONE", ctermbg = "NONE", gui = "underline", cterm = "underline"}}, {hl.group["label-distant"], {guifg = _57_, ctermfg = _62_, guibg = "NONE", ctermbg = "NONE", gui = "bold,underline", cterm = "bold,underline"}}, {hl.group["label-distant-overlapped"], {guifg = _67_, ctermfg = _72_, gui = "underline", cterm = "underline"}}, {hl.group.shortcut, {guibg = "#f00077", ctermbg = "Red", guifg = "#ffffff", ctermfg = "White", gui = "bold,underline", cterm = "bold,underline"}}, {hl.group["one-char-match"], {guibg = "#f00077", ctermbg = "Red", guifg = "#ffffff", ctermfg = "White", gui = "bold", cterm = "bold"}}, {hl.group["masked-ch"], {guifg = _77_, ctermfg = "DarkGrey", guibg = "NONE", ctermbg = "NONE", gui = "NONE", cterm = "NONE"}}, {hl.group["unlabeled-match"], {guifg = _82_, ctermfg = _87_, guibg = "NONE", ctermbg = "NONE", gui = "bold", cterm = "bold"}}, {hl.group["pending-op-area"], {guibg = "#f00077", ctermbg = "Red", guifg = "#ffffff", ctermfg = "White"}}, {hl.group.greywash, {guifg = "#777777", ctermfg = "Grey", guibg = "NONE", ctermbg = "NONE", gui = "NONE", cterm = "NONE"}}}
+  for _, _91_ in ipairs(groupdefs) do
+    local _each_92_ = _91_
+    local group = _each_92_[1]
+    local attrs = _each_92_[2]
     local attrs_str
-    local _78_
+    local _93_
     do
       local tbl_15_auto = {}
       local i_16_auto = #tbl_15_auto
@@ -340,83 +401,83 @@ local function init_highlight(force_3f)
         else
         end
       end
-      _78_ = tbl_15_auto
+      _93_ = tbl_15_auto
     end
-    attrs_str = table.concat(_78_, " ")
-    local function _80_()
+    attrs_str = table.concat(_93_, " ")
+    local function _95_()
       if force_3f then
         return ""
       else
         return "default "
       end
     end
-    vim.cmd(("highlight " .. _80_() .. group .. " " .. attrs_str))
+    vim.cmd(("highlight " .. _95_() .. group .. " " .. attrs_str))
   end
-  for _, _81_ in ipairs({{hl.group["unique-ch"], hl.group["unlabeled-match"]}, {hl.group["shortcut-overlapped"], hl.group.shortcut}, {hl.group.cursor, "Cursor"}}) do
-    local _each_82_ = _81_
-    local from_group = _each_82_[1]
-    local to_group = _each_82_[2]
-    local function _83_()
+  for _, _96_ in ipairs({{hl.group["unique-ch"], hl.group["unlabeled-match"]}, {hl.group["shortcut-overlapped"], hl.group.shortcut}, {hl.group.cursor, "Cursor"}}) do
+    local _each_97_ = _96_
+    local from_group = _each_97_[1]
+    local to_group = _each_97_[2]
+    local function _98_()
       if force_3f then
         return ""
       else
         return "default "
       end
     end
-    vim.cmd(("highlight " .. _83_() .. "link " .. from_group .. " " .. to_group))
+    vim.cmd(("highlight " .. _98_() .. "link " .. from_group .. " " .. to_group))
   end
   return nil
 end
 local function grey_out_search_area(reverse_3f)
-  local _let_84_ = map(dec, get_cursor_pos())
-  local curline = _let_84_[1]
-  local curcol = _let_84_[2]
-  local _let_85_ = {dec(vim.fn.line("w0")), dec(vim.fn.line("w$"))}
-  local win_top = _let_85_[1]
-  local win_bot = _let_85_[2]
-  local function _87_()
+  local _let_99_ = map(dec, get_cursor_pos())
+  local curline = _let_99_[1]
+  local curcol = _let_99_[2]
+  local _let_100_ = {dec(vim.fn.line("w0")), dec(vim.fn.line("w$"))}
+  local win_top = _let_100_[1]
+  local win_bot = _let_100_[2]
+  local function _102_()
     if reverse_3f then
       return {{win_top, 0}, {curline, curcol}}
     else
       return {{curline, inc(curcol)}, {win_bot, -1}}
     end
   end
-  local _let_86_ = _87_()
-  local start = _let_86_[1]
-  local finish = _let_86_[2]
+  local _let_101_ = _102_()
+  local start = _let_101_[1]
+  local finish = _let_101_[2]
   return vim.highlight.range(0, hl.ns, hl.group.greywash, start, finish)
 end
-local function highlight_range(hl_group, _88_, _90_, _92_)
-  local _arg_89_ = _88_
-  local startline = _arg_89_[1]
-  local startcol = _arg_89_[2]
-  local start = _arg_89_
-  local _arg_91_ = _90_
-  local endline = _arg_91_[1]
-  local endcol = _arg_91_[2]
-  local _end = _arg_91_
-  local _arg_93_ = _92_
-  local motion_force = _arg_93_["motion-force"]
-  local inclusive_motion_3f = _arg_93_["inclusive-motion?"]
+local function highlight_range(hl_group, _103_, _105_, _107_)
+  local _arg_104_ = _103_
+  local startline = _arg_104_[1]
+  local startcol = _arg_104_[2]
+  local start = _arg_104_
+  local _arg_106_ = _105_
+  local endline = _arg_106_[1]
+  local endcol = _arg_106_[2]
+  local _end = _arg_106_
+  local _arg_108_ = _107_
+  local motion_force = _arg_108_["motion-force"]
+  local inclusive_motion_3f = _arg_108_["inclusive-motion?"]
   local hl_range
-  local function _94_(start0, _end0, end_inclusive_3f)
+  local function _109_(start0, _end0, end_inclusive_3f)
     return vim.highlight.range(0, hl.ns, hl_group, start0, _end0, nil, end_inclusive_3f)
   end
-  hl_range = _94_
-  local _95_ = motion_force
-  if (_95_ == _3cctrl_v_3e) then
-    local _let_96_ = {min(startcol, endcol), max(startcol, endcol)}
-    local startcol0 = _let_96_[1]
-    local endcol0 = _let_96_[2]
+  hl_range = _109_
+  local _110_ = motion_force
+  if (_110_ == _3cctrl_v_3e) then
+    local _let_111_ = {min(startcol, endcol), max(startcol, endcol)}
+    local startcol0 = _let_111_[1]
+    local endcol0 = _let_111_[2]
     for line = startline, endline do
       hl_range({line, startcol0}, {line, endcol0}, true)
     end
     return nil
-  elseif (_95_ == "V") then
+  elseif (_110_ == "V") then
     return hl_range({startline, 0}, {endline, -1})
-  elseif (_95_ == "v") then
+  elseif (_110_ == "v") then
     return hl_range(start, _end, not inclusive_motion_3f)
-  elseif (_95_ == nil) then
+  elseif (_110_ == nil) then
     return hl_range(start, _end, inclusive_motion_3f)
   else
     return nil
@@ -429,17 +490,17 @@ local function echo_not_found(s)
   return echo(("not found: " .. s))
 end
 local function push_cursor_21(direction)
-  local function _99_()
-    local _98_ = direction
-    if (_98_ == "fwd") then
+  local function _114_()
+    local _113_ = direction
+    if (_113_ == "fwd") then
       return "W"
-    elseif (_98_ == "bwd") then
+    elseif (_113_ == "bwd") then
       return "bW"
     else
       return nil
     end
   end
-  return vim.fn.search("\\_.", _99_())
+  return vim.fn.search("\\_.", _114_())
 end
 local function get_restore_virtualedit_autocmd()
   return ("autocmd " .. "CursorMoved,WinLeave,BufLeave,InsertEnter,CmdlineEnter,CmdwinEnter" .. " * ++once set virtualedit=" .. vim.o.virtualedit)
@@ -451,13 +512,13 @@ end
 local function cursor_before_eof_3f()
   return ((vim.fn.line(".") == vim.fn.line("$")) and (vim.fn.virtcol(".") == dec(vim.fn.virtcol("$"))))
 end
-local function jump_to_21_2a(target, _101_)
-  local _arg_102_ = _101_
-  local mode = _arg_102_["mode"]
-  local reverse_3f = _arg_102_["reverse?"]
-  local inclusive_motion_3f = _arg_102_["inclusive-motion?"]
-  local add_to_jumplist_3f = _arg_102_["add-to-jumplist?"]
-  local adjust = _arg_102_["adjust"]
+local function jump_to_21_2a(target, _116_)
+  local _arg_117_ = _116_
+  local mode = _arg_117_["mode"]
+  local reverse_3f = _arg_117_["reverse?"]
+  local inclusive_motion_3f = _arg_117_["inclusive-motion?"]
+  local add_to_jumplist_3f = _arg_117_["add-to-jumplist?"]
+  local adjust = _arg_117_["adjust"]
   local op_mode_3f = string.match(mode, "o")
   local motion_force = get_motion_force(mode)
   local restore_virtualedit_autocmd = get_restore_virtualedit_autocmd()
@@ -473,8 +534,8 @@ local function jump_to_21_2a(target, _101_)
   end
   local adjusted_pos = get_cursor_pos()
   if (op_mode_3f and not reverse_3f and inclusive_motion_3f) then
-    local _105_ = motion_force
-    if (_105_ == nil) then
+    local _120_ = motion_force
+    if (_120_ == nil) then
       if not cursor_before_eof_3f() then
         push_cursor_21("fwd")
       else
@@ -482,9 +543,9 @@ local function jump_to_21_2a(target, _101_)
         vim.cmd("norm! l")
         vim.cmd(restore_virtualedit_autocmd)
       end
-    elseif (_105_ == "V") then
-    elseif (_105_ == _3cctrl_v_3e) then
-    elseif (_105_ == "v") then
+    elseif (_120_ == "V") then
+    elseif (_120_ == _3cctrl_v_3e) then
+    elseif (_120_ == "v") then
       push_cursor_21("bwd")
     else
     end
@@ -492,47 +553,47 @@ local function jump_to_21_2a(target, _101_)
   end
   return adjusted_pos
 end
-local function get_onscreen_lines(_109_)
-  local _arg_110_ = _109_
-  local reverse_3f = _arg_110_["reverse?"]
-  local skip_folds_3f = _arg_110_["skip-folds?"]
+local function get_onscreen_lines(_124_)
+  local _arg_125_ = _124_
+  local reverse_3f = _arg_125_["reverse?"]
+  local skip_folds_3f = _arg_125_["skip-folds?"]
   local lines = {}
   local wintop = vim.fn.line("w0")
   local winbot = vim.fn.line("w$")
   local lnum = vim.fn.line(".")
   while true do
-    local _111_
+    local _126_
     if reverse_3f then
-      _111_ = (lnum >= wintop)
+      _126_ = (lnum >= wintop)
     else
-      _111_ = (lnum <= winbot)
+      _126_ = (lnum <= winbot)
     end
-    if not _111_ then break end
+    if not _126_ then break end
     local fold_edge = get_fold_edge(lnum, reverse_3f)
     if (skip_folds_3f and fold_edge) then
-      local _113_
+      local _128_
       if reverse_3f then
-        _113_ = dec
+        _128_ = dec
       else
-        _113_ = inc
+        _128_ = inc
       end
-      lnum = _113_(fold_edge)
+      lnum = _128_(fold_edge)
     else
       lines[lnum] = vim.fn.getline(lnum)
-      local _115_
+      local _130_
       if reverse_3f then
-        _115_ = dec
+        _130_ = dec
       else
-        _115_ = inc
+        _130_ = inc
       end
-      lnum = _115_(lnum)
+      lnum = _130_(lnum)
     end
   end
   return lines
 end
-local function get_horizontal_bounds(_118_)
-  local _arg_119_ = _118_
-  local match_width = _arg_119_["match-width"]
+local function get_horizontal_bounds(_133_)
+  local _arg_134_ = _133_
+  local match_width = _arg_134_["match-width"]
   local textoff = (vim.fn.getwininfo(vim.fn.win_getid())[1].textoff or dec(leftmost_editable_wincol()))
   local offset_in_win = vim.fn.wincol()
   local offset_in_editable_win = (offset_in_win - textoff)
@@ -542,11 +603,11 @@ local function get_horizontal_bounds(_118_)
   local right_bound = (right_edge - dec(match_width))
   return {left_bound, right_bound}
 end
-local function onscreen_match_positions(pattern, reverse_3f, _120_)
-  local _arg_121_ = _120_
-  local to_eol_3f = _arg_121_["to-eol?"]
-  local ft_search_3f = _arg_121_["ft-search?"]
-  local limit = _arg_121_["limit"]
+local function onscreen_match_positions(pattern, reverse_3f, _135_)
+  local _arg_136_ = _135_
+  local to_eol_3f = _arg_136_["to-eol?"]
+  local ft_search_3f = _arg_136_["ft-search?"]
+  local limit = _arg_136_["limit"]
   local view = vim.fn.winsaveview()
   local cpo = vim.o.cpo
   local opts0
@@ -556,88 +617,88 @@ local function onscreen_match_positions(pattern, reverse_3f, _120_)
     opts0 = ""
   end
   local stopline
-  local function _123_()
+  local function _138_()
     if reverse_3f then
       return "w0"
     else
       return "w$"
     end
   end
-  stopline = vim.fn.line(_123_())
+  stopline = vim.fn.line(_138_())
   local cleanup
-  local function _124_()
+  local function _139_()
     vim.fn.winrestview(view)
     vim.o.cpo = cpo
     return nil
   end
-  cleanup = _124_
-  local _126_
+  cleanup = _139_
+  local _141_
   if ft_search_3f then
-    _126_ = 1
+    _141_ = 1
   else
-    _126_ = 2
+    _141_ = 2
   end
-  local _let_125_ = get_horizontal_bounds({["match-width"] = _126_})
-  local left_bound = _let_125_[1]
-  local right_bound = _let_125_[2]
+  local _let_140_ = get_horizontal_bounds({["match-width"] = _141_})
+  local left_bound = _let_140_[1]
+  local right_bound = _let_140_[2]
   local function skip_to_fold_edge_21()
-    local _128_
-    local _129_
+    local _143_
+    local _144_
     if reverse_3f then
-      _129_ = vim.fn.foldclosed
+      _144_ = vim.fn.foldclosed
     else
-      _129_ = vim.fn.foldclosedend
+      _144_ = vim.fn.foldclosedend
     end
-    _128_ = _129_(vim.fn.line("."))
-    if (_128_ == -1) then
+    _143_ = _144_(vim.fn.line("."))
+    if (_143_ == -1) then
       return "not-in-fold"
-    elseif (nil ~= _128_) then
-      local fold_edge = _128_
+    elseif (nil ~= _143_) then
+      local fold_edge = _143_
       vim.fn.cursor(fold_edge, 0)
-      local function _131_()
+      local function _146_()
         if reverse_3f then
           return 1
         else
           return vim.fn.col("$")
         end
       end
-      vim.fn.cursor(0, _131_())
+      vim.fn.cursor(0, _146_())
       return "moved-the-cursor"
     else
       return nil
     end
   end
   local function skip_to_next_in_window_pos_21()
-    local _local_133_ = get_cursor_pos()
-    local line = _local_133_[1]
-    local col = _local_133_[2]
-    local from_pos = _local_133_
-    local _134_
+    local _local_148_ = get_cursor_pos()
+    local line = _local_148_[1]
+    local col = _local_148_[2]
+    local from_pos = _local_148_
+    local _149_
     if (col < left_bound) then
       if reverse_3f then
         if (dec(line) >= stopline) then
-          _134_ = {dec(line), right_bound}
+          _149_ = {dec(line), right_bound}
         else
-          _134_ = nil
+          _149_ = nil
         end
       else
-        _134_ = {line, left_bound}
+        _149_ = {line, left_bound}
       end
     elseif (col > right_bound) then
       if reverse_3f then
-        _134_ = {line, right_bound}
+        _149_ = {line, right_bound}
       else
         if (inc(line) <= stopline) then
-          _134_ = {inc(line), left_bound}
+          _149_ = {inc(line), left_bound}
         else
-          _134_ = nil
+          _149_ = nil
         end
       end
     else
-      _134_ = nil
+      _149_ = nil
     end
-    if (nil ~= _134_) then
-      local to_pos = _134_
+    if (nil ~= _149_) then
+      local to_pos = _149_
       if (from_pos ~= to_pos) then
         vim.fn.cursor(to_pos)
         return "moved-the-cursor"
@@ -654,39 +715,39 @@ local function onscreen_match_positions(pattern, reverse_3f, _120_)
     if (limit and (match_count >= limit)) then
       return cleanup()
     else
-      local _142_
-      local function _143_()
+      local _157_
+      local function _158_()
         if match_at_curpos_3f then
           return "c"
         else
           return ""
         end
       end
-      _142_ = vim.fn.searchpos(pattern, (opts0 .. _143_()), stopline)
-      if ((_G.type(_142_) == "table") and ((_142_)[1] == 0) and true) then
-        local _ = (_142_)[2]
+      _157_ = vim.fn.searchpos(pattern, (opts0 .. _158_()), stopline)
+      if ((_G.type(_157_) == "table") and ((_157_)[1] == 0) and true) then
+        local _ = (_157_)[2]
         return cleanup()
-      elseif ((_G.type(_142_) == "table") and (nil ~= (_142_)[1]) and (nil ~= (_142_)[2])) then
-        local line = (_142_)[1]
-        local col = (_142_)[2]
-        local pos = _142_
+      elseif ((_G.type(_157_) == "table") and (nil ~= (_157_)[1]) and (nil ~= (_157_)[2])) then
+        local line = (_157_)[1]
+        local col = (_157_)[2]
+        local pos = _157_
         if ft_search_3f then
           match_count = (match_count + 1)
           return pos
         else
-          local _144_ = skip_to_fold_edge_21()
-          if (_144_ == "moved-the-cursor") then
+          local _159_ = skip_to_fold_edge_21()
+          if (_159_ == "moved-the-cursor") then
             return recur(false)
-          elseif (_144_ == "not-in-fold") then
-            if (vim.wo.wrap or (function(_145_,_146_,_147_) return (_145_ <= _146_) and (_146_ <= _147_) end)(left_bound,col,right_bound) or to_eol_3f) then
+          elseif (_159_ == "not-in-fold") then
+            if (vim.wo.wrap or (function(_160_,_161_,_162_) return (_160_ <= _161_) and (_161_ <= _162_) end)(left_bound,col,right_bound) or to_eol_3f) then
               match_count = (match_count + 1)
               return pos
             else
-              local _148_ = skip_to_next_in_window_pos_21()
-              if (_148_ == "moved-the-cursor") then
+              local _163_ = skip_to_next_in_window_pos_21()
+              if (_163_ == "moved-the-cursor") then
                 return recur(true)
               elseif true then
-                local _ = _148_
+                local _ = _163_
                 return cleanup()
               else
                 return nil
@@ -704,10 +765,10 @@ local function onscreen_match_positions(pattern, reverse_3f, _120_)
   return recur
 end
 local function highlight_cursor(_3fpos)
-  local _let_155_ = (_3fpos or get_cursor_pos())
-  local line = _let_155_[1]
-  local col = _let_155_[2]
-  local pos = _let_155_
+  local _let_170_ = (_3fpos or get_cursor_pos())
+  local line = _let_170_[1]
+  local col = _let_170_[2]
+  local pos = _let_170_
   local ch_at_curpos = (char_at_pos(pos, {}) or " ")
   return hl["set-extmark"](hl, dec(line), dec(col), {virt_text = {{ch_at_curpos, hl.group.cursor}}, virt_text_pos = "overlay", hl_mode = "combine"})
 end
@@ -732,10 +793,10 @@ local function doau_when_exists(event)
 end
 local function enter(mode)
   doau_when_exists("LightspeedEnter")
-  local _158_ = mode
-  if (_158_ == "ft") then
+  local _173_ = mode
+  if (_173_ == "ft") then
     return doau_when_exists("LightspeedFtEnter")
-  elseif (_158_ == "sx") then
+  elseif (_173_ == "sx") then
     return doau_when_exists("LightspeedSxEnter")
   else
     return nil
@@ -744,28 +805,28 @@ end
 local function get_input(_3ftimeout)
   local esc_keycode = 27
   local char_available_3f
-  local function _160_()
+  local function _175_()
     return (0 ~= vim.fn.getchar(1))
   end
-  char_available_3f = _160_
+  char_available_3f = _175_
   local getchar_timeout
-  local function _161_()
+  local function _176_()
     if vim.wait(_3ftimeout, char_available_3f, 100) then
       return vim.fn.getchar(0)
     else
       return nil
     end
   end
-  getchar_timeout = _161_
+  getchar_timeout = _176_
   local ok_3f, ch = nil, nil
-  local function _163_()
+  local function _178_()
     if _3ftimeout then
       return getchar_timeout
     else
       return vim.fn.getchar
     end
   end
-  ok_3f, ch = pcall(_163_())
+  ok_3f, ch = pcall(_178_())
   if (ok_3f and (ch ~= esc_keycode)) then
     if (type(ch) == "number") then
       return vim.fn.nr2char(ch)
@@ -789,40 +850,40 @@ local function set_dot_repeat(cmd, _3fcount)
   return pcall(vim.fn["repeat#set"], seq, -1)
 end
 local function get_plug_key(search_mode, reverse_3f, x_2ft_3f, repeat_invoc)
-  local function _168_()
-    local _167_ = repeat_invoc
-    if (_167_ == "dot") then
+  local function _183_()
+    local _182_ = repeat_invoc
+    if (_182_ == "dot") then
       return "dotrepeat_"
     elseif true then
-      local _ = _167_
+      local _ = _182_
       return ""
     else
       return nil
     end
   end
-  local function _171_()
-    local _170_ = {search_mode, not not reverse_3f, not not x_2ft_3f}
-    if ((_G.type(_170_) == "table") and ((_170_)[1] == "ft") and ((_170_)[2] == false) and ((_170_)[3] == false)) then
+  local function _186_()
+    local _185_ = {search_mode, not not reverse_3f, not not x_2ft_3f}
+    if ((_G.type(_185_) == "table") and ((_185_)[1] == "ft") and ((_185_)[2] == false) and ((_185_)[3] == false)) then
       return "f"
-    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "ft") and ((_170_)[2] == true) and ((_170_)[3] == false)) then
+    elseif ((_G.type(_185_) == "table") and ((_185_)[1] == "ft") and ((_185_)[2] == true) and ((_185_)[3] == false)) then
       return "F"
-    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "ft") and ((_170_)[2] == false) and ((_170_)[3] == true)) then
+    elseif ((_G.type(_185_) == "table") and ((_185_)[1] == "ft") and ((_185_)[2] == false) and ((_185_)[3] == true)) then
       return "t"
-    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "ft") and ((_170_)[2] == true) and ((_170_)[3] == true)) then
+    elseif ((_G.type(_185_) == "table") and ((_185_)[1] == "ft") and ((_185_)[2] == true) and ((_185_)[3] == true)) then
       return "T"
-    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "sx") and ((_170_)[2] == false) and ((_170_)[3] == false)) then
+    elseif ((_G.type(_185_) == "table") and ((_185_)[1] == "sx") and ((_185_)[2] == false) and ((_185_)[3] == false)) then
       return "s"
-    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "sx") and ((_170_)[2] == true) and ((_170_)[3] == false)) then
+    elseif ((_G.type(_185_) == "table") and ((_185_)[1] == "sx") and ((_185_)[2] == true) and ((_185_)[3] == false)) then
       return "S"
-    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "sx") and ((_170_)[2] == false) and ((_170_)[3] == true)) then
+    elseif ((_G.type(_185_) == "table") and ((_185_)[1] == "sx") and ((_185_)[2] == false) and ((_185_)[3] == true)) then
       return "x"
-    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "sx") and ((_170_)[2] == true) and ((_170_)[3] == true)) then
+    elseif ((_G.type(_185_) == "table") and ((_185_)[1] == "sx") and ((_185_)[2] == true) and ((_185_)[3] == true)) then
       return "X"
     else
       return nil
     end
   end
-  return ("<Plug>Lightspeed_" .. _168_() .. _171_())
+  return ("<Plug>Lightspeed_" .. _183_() .. _186_())
 end
 local function get_repeat_action(_in, search_mode, x_2ft_3f, instant_repeat_3f, from_reverse_cold_repeat_3f, _3ftarget_char)
   local mode
@@ -834,22 +895,22 @@ local function get_repeat_action(_in, search_mode, x_2ft_3f, instant_repeat_3f, 
   local in_mapped_to = maparg_expr(_in, mode)
   local repeat_plug_key = ("<Plug>Lightspeed_;_" .. search_mode)
   local revert_plug_key = ("<Plug>Lightspeed_,_" .. search_mode)
-  local _174_
+  local _189_
   if from_reverse_cold_repeat_3f then
-    _174_ = revert_plug_key
+    _189_ = revert_plug_key
   else
-    _174_ = repeat_plug_key
+    _189_ = repeat_plug_key
   end
-  if ((_in == _3cbackspace_3e) or ((search_mode == "ft") and opts.repeat_ft_with_target_char and (_in == _3ftarget_char)) or ((in_mapped_to == get_plug_key(search_mode, false, x_2ft_3f)) or (in_mapped_to == _174_))) then
+  if ((_in == _3cbackspace_3e) or ((search_mode == "ft") and opts.repeat_ft_with_target_char and (_in == _3ftarget_char)) or ((in_mapped_to == get_plug_key(search_mode, false, x_2ft_3f)) or (in_mapped_to == _189_))) then
     return "repeat"
   else
-    local _176_
+    local _191_
     if from_reverse_cold_repeat_3f then
-      _176_ = repeat_plug_key
+      _191_ = repeat_plug_key
     else
-      _176_ = revert_plug_key
+      _191_ = revert_plug_key
     end
-    if (instant_repeat_3f and ((_in == "\9") or ((in_mapped_to == get_plug_key(search_mode, true, x_2ft_3f)) or (in_mapped_to == _176_)))) then
+    if (instant_repeat_3f and ((_in == "\9") or ((in_mapped_to == get_plug_key(search_mode, true, x_2ft_3f)) or (in_mapped_to == _191_)))) then
       return "revert"
     else
       return nil
@@ -870,26 +931,26 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
   end
   local reverted_instant_repeat_3f
   do
-    local t_180_ = instant_state
-    if (nil ~= t_180_) then
-      t_180_ = (t_180_)["reverted?"]
+    local t_195_ = instant_state
+    if (nil ~= t_195_) then
+      t_195_ = (t_195_)["reverted?"]
     else
     end
-    reverted_instant_repeat_3f = t_180_
+    reverted_instant_repeat_3f = t_195_
   end
   local cold_repeat_3f = (repeat_invoc == "cold")
   local dot_repeat_3f = (repeat_invoc == "dot")
   local invoked_as_reverse_3f = reverse_3f
   local reverse_3f0
   if cold_repeat_3f then
-    local function _182_(_241)
+    local function _197_(_241)
       if invoked_as_reverse_3f then
         return not _241
       else
         return _241
       end
     end
-    reverse_3f0 = _182_(self.state.cold["reverse?"])
+    reverse_3f0 = _197_(self.state.cold["reverse?"])
   else
     reverse_3f0 = reverse_3f
   end
@@ -912,28 +973,28 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
     count0 = count
   end
   local function get_num_of_matches_to_be_highlighted()
-    local _188_ = opts.limit_ft_matches
-    local function _189_()
-      local group_limit = _188_
+    local _203_ = opts.limit_ft_matches
+    local function _204_()
+      local group_limit = _203_
       return (group_limit > 0)
     end
-    if ((nil ~= _188_) and _189_()) then
-      local group_limit = _188_
+    if ((nil ~= _203_) and _204_()) then
+      local group_limit = _203_
       local matches_left_behind
-      local function _191_()
-        local _190_ = instant_state
-        if (nil ~= _190_) then
-          local _192_ = (_190_).stack
-          if (nil ~= _192_) then
-            return #_192_
+      local function _206_()
+        local _205_ = instant_state
+        if (nil ~= _205_) then
+          local _207_ = (_205_).stack
+          if (nil ~= _207_) then
+            return #_207_
           else
-            return _192_
+            return _207_
           end
         else
-          return _190_
+          return _205_
         end
       end
-      matches_left_behind = (_191_() or 0)
+      matches_left_behind = (_206_() or 0)
       local eaten_up = (matches_left_behind % group_limit)
       local remaining = (group_limit - eaten_up)
       if (remaining == 0) then
@@ -942,7 +1003,7 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
         return remaining
       end
     elseif true then
-      local _ = _188_
+      local _ = _203_
       return 0
     else
       return nil
@@ -958,16 +1019,16 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
     vim.cmd("redraw")
   else
   end
-  local _199_
+  local _214_
   if instant_repeat_3f then
-    _199_ = instant_state["in"]
+    _214_ = instant_state["in"]
   elseif dot_repeat_3f then
-    _199_ = self.state.dot["in"]
+    _214_ = self.state.dot["in"]
   elseif cold_repeat_3f then
-    _199_ = self.state.cold["in"]
+    _214_ = self.state.cold["in"]
   else
-    local _200_
-    local function _201_()
+    local _215_
+    local function _216_()
       local res_2_auto
       do
         res_2_auto = get_input()
@@ -975,7 +1036,7 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       hl:cleanup()
       return res_2_auto
     end
-    local function _202_()
+    local function _217_()
       if change_operation_3f() then
         handle_interrupted_change_op_21()
       else
@@ -986,9 +1047,9 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       doau_when_exists("LightspeedLeave")
       return nil
     end
-    _200_ = (_201_() or _202_())
-    if (_200_ == _3cbackspace_3e) then
-      local function _204_()
+    _215_ = (_216_() or _217_())
+    if (_215_ == _3cbackspace_3e) then
+      local function _219_()
         if change_operation_3f() then
           handle_interrupted_change_op_21()
         else
@@ -1000,16 +1061,16 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
         doau_when_exists("LightspeedLeave")
         return nil
       end
-      _199_ = (self.state.cold["in"] or _204_())
-    elseif (nil ~= _200_) then
-      local _in = _200_
-      _199_ = _in
+      _214_ = (self.state.cold["in"] or _219_())
+    elseif (nil ~= _215_) then
+      local _in = _215_
+      _214_ = _in
     else
-      _199_ = nil
+      _214_ = nil
     end
   end
-  if (nil ~= _199_) then
-    local in1 = _199_
+  if (nil ~= _214_) then
+    local in1 = _214_
     local to_eol_3f = (in1 == "\13")
     if not repeat_invoc then
       self.state.cold = {["in"] = in1, ["reverse?"] = reverse_3f0, ["t-mode?"] = t_mode_3f0}
@@ -1019,33 +1080,33 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
     local match_count = 0
     do
       local next_pos
-      local function _209_()
+      local function _224_()
         if reverse_3f0 then
           return "nWb"
         else
           return "nW"
         end
       end
-      next_pos = vim.fn.searchpos("\\_.", _209_())
+      next_pos = vim.fn.searchpos("\\_.", _224_())
       local pattern
       if to_eol_3f then
         pattern = "\\n"
       else
-        local function _210_()
+        local function _225_()
           if opts.ignore_case then
             return "\\c"
           else
             return "\\C"
           end
         end
-        pattern = ("\\V" .. _210_() .. in1:gsub("\\", "\\\\"))
+        pattern = ("\\V" .. _225_() .. in1:gsub("\\", "\\\\"))
       end
       local limit = (count0 + get_num_of_matches_to_be_highlighted())
-      for _212_ in onscreen_match_positions(pattern, reverse_3f0, {["ft-search?"] = true, limit = limit}) do
-        local _each_213_ = _212_
-        local line = _each_213_[1]
-        local col = _each_213_[2]
-        local pos = _each_213_
+      for _227_ in onscreen_match_positions(pattern, reverse_3f0, {["ft-search?"] = true, limit = limit}) do
+        local _each_228_ = _227_
+        local line = _each_228_[1]
+        local col = _each_228_[2]
+        local pos = _each_228_
         if not ((match_count == 0) and cold_repeat_3f and t_mode_3f0 and same_pos_3f(pos, next_pos)) then
           if (match_count <= dec(count0)) then
             jump_pos = pos
@@ -1073,16 +1134,16 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       return nil
     else
       if not reverted_instant_repeat_3f then
-        local function _218_()
+        local function _233_()
           if t_mode_3f0 then
-            local function _219_()
+            local function _234_()
               if reverse_3f0 then
                 return "fwd"
               else
                 return "bwd"
               end
             end
-            push_cursor_21(_219_())
+            push_cursor_21(_234_())
             if (to_eol_3f and not reverse_3f0 and mode:match("n")) then
               return push_cursor_21("fwd")
             else
@@ -1092,7 +1153,7 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
             return nil
           end
         end
-        jump_to_21_2a(jump_pos, {mode = mode, ["reverse?"] = reverse_3f0, ["inclusive-motion?"] = true, ["add-to-jumplist?"] = not instant_repeat_3f, adjust = _218_})
+        jump_to_21_2a(jump_pos, {mode = mode, ["reverse?"] = reverse_3f0, ["inclusive-motion?"] = true, ["add-to-jumplist?"] = not instant_repeat_3f, adjust = _233_})
       else
       end
       if op_mode_3f then
@@ -1109,8 +1170,8 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       else
         highlight_cursor()
         vim.cmd("redraw")
-        local _224_
-        local function _225_()
+        local _239_
+        local function _240_()
           local res_2_auto
           do
             res_2_auto = get_input(opts.exit_after_idle_msecs.unlabeled)
@@ -1118,47 +1179,47 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
           hl:cleanup()
           return res_2_auto
         end
-        local function _226_()
+        local function _241_()
           do
           end
           doau_when_exists("LightspeedFtLeave")
           doau_when_exists("LightspeedLeave")
           return nil
         end
-        _224_ = (_225_() or _226_())
-        if (nil ~= _224_) then
-          local in2 = _224_
+        _239_ = (_240_() or _241_())
+        if (nil ~= _239_) then
+          local in2 = _239_
           local stack
-          local function _228_()
-            local t_227_ = instant_state
-            if (nil ~= t_227_) then
-              t_227_ = (t_227_).stack
+          local function _243_()
+            local t_242_ = instant_state
+            if (nil ~= t_242_) then
+              t_242_ = (t_242_).stack
             else
             end
-            return t_227_
+            return t_242_
           end
-          stack = (_228_() or {})
+          stack = (_243_() or {})
           local from_reverse_cold_repeat_3f
           if instant_repeat_3f then
             from_reverse_cold_repeat_3f = instant_state["from-reverse-cold-repeat?"]
           else
             from_reverse_cold_repeat_3f = (cold_repeat_3f and invoked_as_reverse_3f)
           end
-          local _231_ = get_repeat_action(in2, "ft", t_mode_3f0, instant_repeat_3f, from_reverse_cold_repeat_3f, in1)
-          if (_231_ == "repeat") then
+          local _246_ = get_repeat_action(in2, "ft", t_mode_3f0, instant_repeat_3f, from_reverse_cold_repeat_3f, in1)
+          if (_246_ == "repeat") then
             table.insert(stack, get_cursor_pos())
             return ft:go(reverse_3f0, t_mode_3f0, {["in"] = in1, stack = stack, ["reverted?"] = false, ["from-reverse-cold-repeat?"] = from_reverse_cold_repeat_3f})
-          elseif (_231_ == "revert") then
+          elseif (_246_ == "revert") then
             do
-              local _232_ = table.remove(stack)
-              if (nil ~= _232_) then
-                vim.fn.cursor(_232_)
+              local _247_ = table.remove(stack)
+              if (nil ~= _247_) then
+                vim.fn.cursor(_247_)
               else
               end
             end
             return ft:go(reverse_3f0, t_mode_3f0, {["in"] = in1, stack = stack, ["reverted?"] = true, ["from-reverse-cold-repeat?"] = from_reverse_cold_repeat_3f})
           elseif true then
-            local _ = _231_
+            local _ = _246_
             do
               vim.fn.feedkeys(in2, "i")
             end
@@ -1179,23 +1240,23 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
 end
 do
   local deprec_msg = {{"ligthspeed.nvim", "Question"}, {": You're trying to access deprecated fields in the lightspeed.ft table.\n"}, {"There are dedicated <Plug> keys available for native-like "}, {";", "Visual"}, {" and "}, {",", "Visual"}, {" functionality now.\n"}, {"See "}, {":h lightspeed-custom-mappings", "Visual"}, {"."}}
-  local function _239_(t, k)
+  local function _254_(t, k)
     if ((k == "instant-repeat?") or (k == "prev-t-like?")) then
       return api.nvim_echo(deprec_msg, true, {})
     else
       return nil
     end
   end
-  setmetatable(ft, {__index = _239_})
+  setmetatable(ft, {__index = _254_})
 end
 local function highlight_unique_chars(reverse_3f)
   local unique_chars = {}
-  local _let_241_ = get_horizontal_bounds({["match-width"] = 2})
-  local left_bound = _let_241_[1]
-  local right_bound = _let_241_[2]
-  local _let_242_ = get_cursor_pos()
-  local curline = _let_242_[1]
-  local curcol = _let_242_[2]
+  local _let_256_ = get_horizontal_bounds({["match-width"] = 2})
+  local left_bound = _let_256_[1]
+  local right_bound = _let_256_[2]
+  local _let_257_ = get_cursor_pos()
+  local curline = _let_257_[1]
+  local curcol = _let_257_[2]
   for lnum, line in pairs(get_onscreen_lines({["reverse?"] = reverse_3f, ["skip-folds?"] = true})) do
     local on_curline_3f = (lnum == curline)
     local startcol
@@ -1219,29 +1280,29 @@ local function highlight_unique_chars(reverse_3f)
         else
           ch0 = ch
         end
-        local _247_
+        local _262_
         do
-          local _246_ = unique_chars[ch0]
-          if (nil ~= _246_) then
-            local pos_already_there = _246_
-            _247_ = false
+          local _261_ = unique_chars[ch0]
+          if (nil ~= _261_) then
+            local pos_already_there = _261_
+            _262_ = false
           elseif true then
-            local _ = _246_
-            _247_ = {lnum, col}
+            local _ = _261_
+            _262_ = {lnum, col}
           else
-            _247_ = nil
+            _262_ = nil
           end
         end
-        unique_chars[ch0] = _247_
+        unique_chars[ch0] = _262_
       else
       end
     end
   end
   for ch, pos in pairs(unique_chars) do
-    local _252_ = pos
-    if ((_G.type(_252_) == "table") and (nil ~= (_252_)[1]) and (nil ~= (_252_)[2])) then
-      local lnum = (_252_)[1]
-      local col = (_252_)[2]
+    local _267_ = pos
+    if ((_G.type(_267_) == "table") and (nil ~= (_267_)[1]) and (nil ~= (_267_)[2])) then
+      local lnum = (_267_)[1]
+      local col = (_267_)[2]
       hl["add-hl"](hl, hl.group["unique-ch"], dec(lnum), dec(col), col)
     else
     end
@@ -1257,20 +1318,20 @@ local function get_targets(input, reverse_3f)
   if to_eol_3f then
     pattern = "\\n"
   else
-    local function _254_()
+    local function _269_()
       if opts.ignore_case then
         return "\\c"
       else
         return "\\C"
       end
     end
-    pattern = ("\\V" .. _254_() .. input:gsub("\\", "\\\\") .. "\\_.")
+    pattern = ("\\V" .. _269_() .. input:gsub("\\", "\\\\") .. "\\_.")
   end
-  for _256_ in onscreen_match_positions(pattern, reverse_3f, {["to-eol?"] = to_eol_3f}) do
-    local _each_257_ = _256_
-    local line = _each_257_[1]
-    local col = _each_257_[2]
-    local pos = _each_257_
+  for _271_ in onscreen_match_positions(pattern, reverse_3f, {["to-eol?"] = to_eol_3f}) do
+    local _each_272_ = _271_
+    local line = _each_272_[1]
+    local col = _each_272_[2]
+    local pos = _each_272_
     if to_eol_3f then
       table.insert(targets, {pos = pos, pair = {"\n", ""}})
     else
@@ -1278,13 +1339,13 @@ local function get_targets(input, reverse_3f)
       local ch2 = (char_at_pos(pos, {["char-offset"] = 1}) or "\13")
       local to_pre_eol_3f = (ch2 == "\13")
       local overlaps_prev_match_3f
-      local _258_
+      local _273_
       if reverse_3f then
-        _258_ = dec
+        _273_ = dec
       else
-        _258_ = inc
+        _273_ = inc
       end
-      overlaps_prev_match_3f = ((line == prev_match.line) and (col == _258_(prev_match.col)))
+      overlaps_prev_match_3f = ((line == prev_match.line) and (col == _273_(prev_match.col)))
       local same_char_triplet_3f = (overlaps_prev_match_3f and (ch2 == prev_match.ch2))
       local overlaps_prev_target_3f = (overlaps_prev_match_3f and added_prev_match_3f)
       prev_match = {line = line, col = col, ch2 = ch2}
@@ -1296,11 +1357,11 @@ local function get_targets(input, reverse_3f)
         local match_width = 2
         local touches_prev_target_3f
         do
-          local _260_ = prev_target
-          if ((_G.type(_260_) == "table") and ((_G.type((_260_).pos) == "table") and (nil ~= ((_260_).pos)[1]) and (nil ~= ((_260_).pos)[2]))) then
-            local prev_line = ((_260_).pos)[1]
-            local prev_col = ((_260_).pos)[2]
-            local function _262_()
+          local _275_ = prev_target
+          if ((_G.type(_275_) == "table") and ((_G.type((_275_).pos) == "table") and (nil ~= ((_275_).pos)[1]) and (nil ~= ((_275_).pos)[2]))) then
+            local prev_line = ((_275_).pos)[1]
+            local prev_col = ((_275_).pos)[2]
+            local function _277_()
               local col_delta
               if reverse_3f then
                 col_delta = (prev_col - col)
@@ -1309,7 +1370,7 @@ local function get_targets(input, reverse_3f)
               end
               return (col_delta <= match_width)
             end
-            touches_prev_target_3f = ((line == prev_line) and _262_())
+            touches_prev_target_3f = ((line == prev_line) and _277_())
           else
             touches_prev_target_3f = nil
           end
@@ -1319,23 +1380,23 @@ local function get_targets(input, reverse_3f)
         else
         end
         if touches_prev_target_3f then
-          local _265_
+          local _280_
           if reverse_3f then
-            _265_ = target
+            _280_ = target
           else
-            _265_ = prev_target
+            _280_ = prev_target
           end
-          _265_["squeezed?"] = true
+          _280_["squeezed?"] = true
         else
         end
         if overlaps_prev_target_3f then
-          local _268_
+          local _283_
           if reverse_3f then
-            _268_ = prev_target
+            _283_ = prev_target
           else
-            _268_ = target
+            _283_ = target
           end
-          _268_["overlapped?"] = true
+          _283_["overlapped?"] = true
         else
         end
         table.insert(targets, target)
@@ -1352,18 +1413,18 @@ end
 local function populate_sublists(targets)
   targets["sublists"] = {}
   if opts.ignore_case then
-    local function _274_(self, k)
+    local function _289_(self, k)
       return rawget(self, k:lower())
     end
-    setmetatable(targets.sublists, {__index = _274_})
+    setmetatable(targets.sublists, {__index = _289_})
   else
   end
-  for _, _276_ in ipairs(targets) do
-    local _each_277_ = _276_
-    local _each_278_ = _each_277_["pair"]
-    local _0 = _each_278_[1]
-    local ch2 = _each_278_[2]
-    local target = _each_277_
+  for _, _291_ in ipairs(targets) do
+    local _each_292_ = _291_
+    local _each_293_ = _each_292_["pair"]
+    local _0 = _each_293_[1]
+    local ch2 = _each_293_[2]
+    local target = _each_292_
     local k
     if opts.ignore_case then
       k = ch2:lower()
@@ -1396,12 +1457,12 @@ local function get_labels(sublist, to_eol_3f)
     end
     return opts.safe_labels
   else
-    local _284_ = sublist["autojump?"]
-    if (_284_ == true) then
+    local _299_ = sublist["autojump?"]
+    if (_299_ == true) then
       return opts.safe_labels
-    elseif (_284_ == false) then
+    elseif (_299_ == false) then
       return opts.labels
-    elseif (_284_ == nil) then
+    elseif (_299_ == nil) then
       sublist["autojump?"] = (not operator_pending_mode_3f() and (dec(#sublist) <= #opts.safe_labels))
       return get_labels(sublist)
     else
@@ -1414,66 +1475,66 @@ local function set_labels(targets, to_eol_3f)
     if (#sublist > 1) then
       local labels = get_labels(sublist, to_eol_3f)
       for i, target in ipairs(sublist) do
-        local _287_
+        local _302_
         if not (sublist["autojump?"] and (i == 1)) then
-          local _288_
-          local function _290_()
+          local _303_
+          local function _305_()
             if sublist["autojump?"] then
               return dec(i)
             else
               return i
             end
           end
-          _288_ = (_290_() % #labels)
-          if (_288_ == 0) then
-            _287_ = last(labels)
-          elseif (nil ~= _288_) then
-            local n = _288_
-            _287_ = labels[n]
+          _303_ = (_305_() % #labels)
+          if (_303_ == 0) then
+            _302_ = last(labels)
+          elseif (nil ~= _303_) then
+            local n = _303_
+            _302_ = labels[n]
           else
-            _287_ = nil
+            _302_ = nil
           end
         else
-          _287_ = nil
+          _302_ = nil
         end
-        target["label"] = _287_
+        target["label"] = _302_
       end
     else
     end
   end
   return nil
 end
-local function set_label_states_for_sublist(sublist, _296_)
-  local _arg_297_ = _296_
-  local group_offset = _arg_297_["group-offset"]
+local function set_label_states_for_sublist(sublist, _311_)
+  local _arg_312_ = _311_
+  local group_offset = _arg_312_["group-offset"]
   local labels = get_labels(sublist)
   local _7clabels_7c = #labels
   local offset = (group_offset * _7clabels_7c)
   local primary_start
-  local function _298_()
+  local function _313_()
     if sublist["autojump?"] then
       return 2
     else
       return 1
     end
   end
-  primary_start = (offset + _298_())
+  primary_start = (offset + _313_())
   local primary_end = (primary_start + dec(_7clabels_7c))
   local secondary_end = (primary_end + _7clabels_7c)
   for i, target in ipairs(sublist) do
-    local _299_
+    local _314_
     if target.label then
       if ((i < primary_start) or (i > secondary_end)) then
-        _299_ = "inactive"
+        _314_ = "inactive"
       elseif (i <= primary_end) then
-        _299_ = "active-primary"
+        _314_ = "active-primary"
       else
-        _299_ = "active-secondary"
+        _314_ = "active-secondary"
       end
     else
-      _299_ = nil
+      _314_ = nil
     end
-    target["label-state"] = _299_
+    target["label-state"] = _314_
   end
   return nil
 end
@@ -1489,10 +1550,10 @@ local function set_shortcuts_and_populate_shortcuts_map(targets)
   do
     local tbl_12_auto = {}
     for ch2, _ in pairs(targets.sublists) do
-      local _302_, _303_ = ch2, true
-      if ((nil ~= _302_) and (nil ~= _303_)) then
-        local k_13_auto = _302_
-        local v_14_auto = _303_
+      local _317_, _318_ = ch2, true
+      if ((nil ~= _317_) and (nil ~= _318_)) then
+        local k_13_auto = _317_
+        local v_14_auto = _318_
         tbl_12_auto[k_13_auto] = v_14_auto
       else
       end
@@ -1500,11 +1561,11 @@ local function set_shortcuts_and_populate_shortcuts_map(targets)
     potential_2nd_inputs = tbl_12_auto
   end
   local labels_used_up_as_shortcut = {}
-  for _, _305_ in ipairs(targets) do
-    local _each_306_ = _305_
-    local label = _each_306_["label"]
-    local label_state = _each_306_["label-state"]
-    local target = _each_306_
+  for _, _320_ in ipairs(targets) do
+    local _each_321_ = _320_
+    local label = _each_321_["label"]
+    local label_state = _each_321_["label-state"]
+    local target = _each_321_
     if (label_state == "active-primary") then
       if not ((potential_2nd_inputs)[label] or labels_used_up_as_shortcut[label]) then
         target["shortcut?"] = true
@@ -1517,30 +1578,30 @@ local function set_shortcuts_and_populate_shortcuts_map(targets)
   end
   return nil
 end
-local function set_beacon(_309_, _repeat)
-  local _arg_310_ = _309_
-  local _arg_311_ = _arg_310_["pos"]
-  local _ = _arg_311_[1]
-  local col = _arg_311_[2]
-  local _arg_312_ = _arg_310_["pair"]
-  local ch1 = _arg_312_[1]
-  local ch2 = _arg_312_[2]
-  local label = _arg_310_["label"]
-  local label_state = _arg_310_["label-state"]
-  local squeezed_3f = _arg_310_["squeezed?"]
-  local overlapped_3f = _arg_310_["overlapped?"]
-  local shortcut_3f = _arg_310_["shortcut?"]
-  local target = _arg_310_
+local function set_beacon(_324_, _repeat)
+  local _arg_325_ = _324_
+  local _arg_326_ = _arg_325_["pos"]
+  local _ = _arg_326_[1]
+  local col = _arg_326_[2]
+  local _arg_327_ = _arg_325_["pair"]
+  local ch1 = _arg_327_[1]
+  local ch2 = _arg_327_[2]
+  local label = _arg_325_["label"]
+  local label_state = _arg_325_["label-state"]
+  local squeezed_3f = _arg_325_["squeezed?"]
+  local overlapped_3f = _arg_325_["overlapped?"]
+  local shortcut_3f = _arg_325_["shortcut?"]
+  local target = _arg_325_
   local to_eol_3f = ((ch1 == "\n") and (ch2 == ""))
-  local _let_313_ = get_horizontal_bounds({["match-width"] = 1})
-  local left_bound = _let_313_[1]
-  local right_bound = _let_313_[2]
-  local function _315_(_241)
+  local _let_328_ = get_horizontal_bounds({["match-width"] = 1})
+  local left_bound = _let_328_[1]
+  local right_bound = _let_328_[2]
+  local function _330_(_241)
     return (opts.substitute_chars[_241] or _241)
   end
-  local _let_314_ = map(_315_, {ch1, ch2})
-  local ch10 = _let_314_[1]
-  local ch20 = _let_314_[2]
+  local _let_329_ = map(_330_, {ch1, ch2})
+  local ch10 = _let_329_[1]
+  local ch20 = _let_329_[2]
   local masked_char_24 = {ch20, hl.group["masked-ch"]}
   local label_24 = {label, hl.group.label}
   local shortcut_24 = {label, hl.group.shortcut}
@@ -1549,8 +1610,8 @@ local function set_beacon(_309_, _repeat)
   local overlapped_shortcut_24 = {label, hl.group["shortcut-overlapped"]}
   local overlapped_distant_label_24 = {label, hl.group["label-distant-overlapped"]}
   do
-    local _316_ = label_state
-    if (_316_ == nil) then
+    local _331_ = label_state
+    if (_331_ == nil) then
       if not (_repeat or to_eol_3f) then
         if overlapped_3f then
           target.beacon = {1, {{ch20, hl.group["unlabeled-match"]}}}
@@ -1560,7 +1621,7 @@ local function set_beacon(_309_, _repeat)
       else
         target.beacon = nil
       end
-    elseif (_316_ == "active-primary") then
+    elseif (_331_ == "active-primary") then
       if to_eol_3f then
         if (vim.wo.wrap or ((col <= right_bound) and (col >= left_bound))) then
           target.beacon = {0, {shortcut_24}}
@@ -1572,13 +1633,13 @@ local function set_beacon(_309_, _repeat)
           target.beacon = nil
         end
       elseif _repeat then
-        local _320_
+        local _335_
         if squeezed_3f then
-          _320_ = 1
+          _335_ = 1
         else
-          _320_ = 2
+          _335_ = 2
         end
-        target.beacon = {_320_, {shortcut_24}}
+        target.beacon = {_335_, {shortcut_24}}
       elseif shortcut_3f then
         if overlapped_3f then
           target.beacon = {1, {overlapped_shortcut_24}}
@@ -1596,7 +1657,7 @@ local function set_beacon(_309_, _repeat)
       else
         target.beacon = {2, {label_24}}
       end
-    elseif (_316_ == "active-secondary") then
+    elseif (_331_ == "active-secondary") then
       if to_eol_3f then
         if (vim.wo.wrap or ((col <= right_bound) and (col >= left_bound))) then
           target.beacon = {0, {distant_label_24}}
@@ -1608,13 +1669,13 @@ local function set_beacon(_309_, _repeat)
           target.beacon = nil
         end
       elseif _repeat then
-        local _326_
+        local _341_
         if squeezed_3f then
-          _326_ = 1
+          _341_ = 1
         else
-          _326_ = 2
+          _341_ = 2
         end
-        target.beacon = {_326_, {distant_label_24}}
+        target.beacon = {_341_, {distant_label_24}}
       elseif overlapped_3f then
         target.beacon = {1, {overlapped_distant_label_24}}
       elseif squeezed_3f then
@@ -1622,7 +1683,7 @@ local function set_beacon(_309_, _repeat)
       else
         target.beacon = {2, {distant_label_24}}
       end
-    elseif (_316_ == "inactive") then
+    elseif (_331_ == "inactive") then
       target.beacon = nil
     else
       target.beacon = nil
@@ -1630,9 +1691,9 @@ local function set_beacon(_309_, _repeat)
   end
   return nil
 end
-local function set_beacons(target_list, _330_)
-  local _arg_331_ = _330_
-  local _repeat = _arg_331_["repeat"]
+local function set_beacons(target_list, _345_)
+  local _arg_346_ = _345_
+  local _repeat = _arg_346_["repeat"]
   for _, target in ipairs(target_list) do
     set_beacon(target, _repeat)
   end
@@ -1640,23 +1701,23 @@ local function set_beacons(target_list, _330_)
 end
 local function light_up_beacons(target_list, _3fstart_idx)
   for i = (_3fstart_idx or 1), #target_list do
-    local _let_332_ = target_list[i]
-    local _let_333_ = _let_332_["pos"]
-    local line = _let_333_[1]
-    local col = _let_333_[2]
-    local beacon = _let_332_["beacon"]
-    local _334_ = beacon
-    if ((_G.type(_334_) == "table") and (nil ~= (_334_)[1]) and (nil ~= (_334_)[2]) and true) then
-      local offset = (_334_)[1]
-      local chunks = (_334_)[2]
-      local _3fleft_off_3f = (_334_)[3]
-      local _335_
+    local _let_347_ = target_list[i]
+    local _let_348_ = _let_347_["pos"]
+    local line = _let_348_[1]
+    local col = _let_348_[2]
+    local beacon = _let_347_["beacon"]
+    local _349_ = beacon
+    if ((_G.type(_349_) == "table") and (nil ~= (_349_)[1]) and (nil ~= (_349_)[2]) and true) then
+      local offset = (_349_)[1]
+      local chunks = (_349_)[2]
+      local _3fleft_off_3f = (_349_)[3]
+      local _350_
       if _3fleft_off_3f then
-        _335_ = 0
+        _350_ = 0
       else
-        _335_ = nil
+        _350_ = nil
       end
-      hl["set-extmark"](hl, dec(line), dec((col + offset)), {virt_text = chunks, virt_text_pos = "overlay", virt_text_win_col = _335_})
+      hl["set-extmark"](hl, dec(line), dec((col + offset)), {virt_text = chunks, virt_text_pos = "overlay", virt_text_win_col = _350_})
     else
     end
   end
@@ -1664,11 +1725,11 @@ local function light_up_beacons(target_list, _3fstart_idx)
 end
 local function get_target_with_active_primary_label(target_list, input)
   local res = nil
-  for _, _338_ in ipairs(target_list) do
-    local _each_339_ = _338_
-    local label = _each_339_["label"]
-    local label_state = _each_339_["label-state"]
-    local target = _each_339_
+  for _, _353_ in ipairs(target_list) do
+    local _each_354_ = _353_
+    local label = _each_354_["label"]
+    local label_state = _each_354_["label-state"]
+    local target = _each_354_
     if res then break end
     if ((label == input) and (label_state == "active-primary")) then
       res = target
@@ -1678,9 +1739,9 @@ local function get_target_with_active_primary_label(target_list, input)
   return res
 end
 local function ignore_input_until_timeout(char_to_ignore)
-  local _341_ = get_input(opts.jump_on_partial_input_safety_timeout)
-  if (nil ~= _341_) then
-    local input = _341_
+  local _356_ = get_input(opts.jump_on_partial_input_safety_timeout)
+  if (nil ~= _356_) then
+    local input = _356_
     if (input ~= char_to_ignore) then
       return vim.fn.feedkeys(input, "i")
     else
@@ -1709,14 +1770,14 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
   local invoked_as_reverse_3f = reverse_3f
   local reverse_3f0
   if cold_repeat_3f then
-    local function _345_(_241)
+    local function _360_(_241)
       if invoked_as_reverse_3f then
         return not _241
       else
         return _241
       end
     end
-    reverse_3f0 = _345_(self.state.cold["reverse?"])
+    reverse_3f0 = _360_(self.state.cold["reverse?"])
   else
     reverse_3f0 = reverse_3f
   end
@@ -1738,8 +1799,8 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     elseif cold_repeat_3f then
       return self.state.cold.in1
     else
-      local _349_
-      local function _350_()
+      local _364_
+      local function _365_()
         local res_2_auto
         do
           res_2_auto = get_input()
@@ -1747,7 +1808,7 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         hl:cleanup()
         return res_2_auto
       end
-      local function _351_()
+      local function _366_()
         if change_operation_3f() then
           handle_interrupted_change_op_21()
         else
@@ -1758,11 +1819,11 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         doau_when_exists("LightspeedLeave")
         return nil
       end
-      _349_ = (_350_() or _351_())
-      if (_349_ == _3cbackspace_3e) then
+      _364_ = (_365_() or _366_())
+      if (_364_ == _3cbackspace_3e) then
         backspace_repeat_3f = true
         new_search_3f = false
-        local function _353_()
+        local function _368_()
           if change_operation_3f() then
             handle_interrupted_change_op_21()
           else
@@ -1774,9 +1835,9 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
           doau_when_exists("LightspeedLeave")
           return nil
         end
-        return (self.state.cold.in1 or _353_())
-      elseif (nil ~= _349_) then
-        local _in = _349_
+        return (self.state.cold.in1 or _368_())
+      elseif (nil ~= _364_) then
+        local _in = _364_
         return _in
       else
         return nil
@@ -1784,26 +1845,26 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     end
   end
   local function update_state_2a(in1)
-    local function _359_(_357_)
-      local _arg_358_ = _357_
-      local cold = _arg_358_["cold"]
-      local dot = _arg_358_["dot"]
+    local function _374_(_372_)
+      local _arg_373_ = _372_
+      local cold = _arg_373_["cold"]
+      local dot = _arg_373_["dot"]
       if new_search_3f then
         if cold then
-          local _360_ = cold
-          _360_["in1"] = in1
-          _360_["x-mode?"] = x_mode_3f0
-          _360_["reverse?"] = reverse_3f0
-          self.state.cold = _360_
+          local _375_ = cold
+          _375_["in1"] = in1
+          _375_["x-mode?"] = x_mode_3f0
+          _375_["reverse?"] = reverse_3f0
+          self.state.cold = _375_
         else
         end
         if dot then
           if dot_repeatable_op_3f then
             do
-              local _362_ = dot
-              _362_["in1"] = in1
-              _362_["x-mode?"] = x_mode_3f0
-              self.state.dot = _362_
+              local _377_ = dot
+              _377_["in1"] = in1
+              _377_["x-mode?"] = x_mode_3f0
+              self.state.dot = _377_
             end
             return nil
           else
@@ -1816,15 +1877,15 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         return nil
       end
     end
-    return _359_
+    return _374_
   end
   local jump_to_21
   do
     local first_jump_3f = true
-    local function _366_(target, _3fto_pre_eol_3f)
+    local function _381_(target, _3fto_pre_eol_3f)
       local to_pre_eol_3f0 = (_3fto_pre_eol_3f or to_pre_eol_3f)
       local adjusted_pos
-      local function _367_()
+      local function _382_()
         if to_eol_3f then
           if op_mode_3f then
             return push_cursor_21("fwd")
@@ -1848,37 +1909,37 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
           return nil
         end
       end
-      adjusted_pos = jump_to_21_2a(target, {mode = mode, ["reverse?"] = reverse_3f0, ["inclusive-motion?"] = (x_mode_3f0 and not reverse_3f0), ["add-to-jumplist?"] = (first_jump_3f and not instant_repeat_3f), adjust = _367_})
+      adjusted_pos = jump_to_21_2a(target, {mode = mode, ["reverse?"] = reverse_3f0, ["inclusive-motion?"] = (x_mode_3f0 and not reverse_3f0), ["add-to-jumplist?"] = (first_jump_3f and not instant_repeat_3f), adjust = _382_})
       first_jump_3f = false
       return adjusted_pos
     end
-    jump_to_21 = _366_
+    jump_to_21 = _381_
   end
   local function highlight_new_curpos_and_op_area(from_pos, to_pos)
     local motion_force = get_motion_force(mode)
     local blockwise_3f = (motion_force == _3cctrl_v_3e)
-    local function _373_()
+    local function _388_()
       if reverse_3f0 then
         return to_pos
       else
         return from_pos
       end
     end
-    local _let_372_ = _373_()
-    local startline = _let_372_[1]
-    local startcol = _let_372_[2]
-    local start = _let_372_
-    local function _375_()
+    local _let_387_ = _388_()
+    local startline = _let_387_[1]
+    local startcol = _let_387_[2]
+    local start = _let_387_
+    local function _390_()
       if reverse_3f0 then
         return from_pos
       else
         return to_pos
       end
     end
-    local _let_374_ = _375_()
-    local _ = _let_374_[1]
-    local endcol = _let_374_[2]
-    local _end = _let_374_
+    local _let_389_ = _390_()
+    local _ = _let_389_[1]
+    local endcol = _let_389_[2]
+    local _end = _let_389_
     local top_left = {startline, min(startcol, endcol)}
     local new_curpos
     if op_mode_3f then
@@ -1901,15 +1962,15 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     return vim.cmd("redraw")
   end
   local function get_sublist(targets, ch)
-    local _380_ = targets.sublists[ch]
-    if (nil ~= _380_) then
-      local sublist = _380_
-      local _let_381_ = sublist
-      local _let_382_ = _let_381_[1]
-      local _let_383_ = _let_382_["pos"]
-      local line = _let_383_[1]
-      local col = _let_383_[2]
-      local rest = (function (t, k) local mt = getmetatable(t) if "table" == type(mt) and mt.__fennelrest then return mt.__fennelrest(t, k) else return {(table.unpack or unpack)(t, k)} end end)(_let_381_, 2)
+    local _395_ = targets.sublists[ch]
+    if (nil ~= _395_) then
+      local sublist = _395_
+      local _let_396_ = sublist
+      local _let_397_ = _let_396_[1]
+      local _let_398_ = _let_397_["pos"]
+      local line = _let_398_[1]
+      local col = _let_398_[2]
+      local rest = (function (t, k) local mt = getmetatable(t) if "table" == type(mt) and mt.__fennelrest then return mt.__fennelrest(t, k) else return {(table.unpack or unpack)(t, k)} end end)(_let_396_, 2)
       local target_tail = {line, inc(col)}
       local prev_pos = vim.fn.searchpos("\\_.", "nWb")
       local cursor_touches_first_target_3f = same_pos_3f(target_tail, prev_pos)
@@ -1930,15 +1991,15 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     local next_group_key = replace_keycodes(opts.cycle_group_fwd_key)
     local prev_group_key = replace_keycodes(opts.cycle_group_bwd_key)
     local function recur(group_offset, initial_invoc_3f)
-      local _387_
+      local _402_
       if (cold_repeat_3f or backspace_repeat_3f) then
-        _387_ = "cold"
+        _402_ = "cold"
       elseif instant_repeat_3f then
-        _387_ = "instant"
+        _402_ = "instant"
       else
-        _387_ = nil
+        _402_ = nil
       end
-      set_beacons(sublist, {["repeat"] = _387_})
+      set_beacons(sublist, {["repeat"] = _402_})
       do
         if (opts.grey_out_search_area and not (cold_repeat_3f or instant_repeat_3f or to_eol_3f)) then
           grey_out_search_area(reverse_3f0)
@@ -1950,24 +2011,24 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         highlight_cursor()
         vim.cmd("redraw")
       end
-      local _390_
+      local _405_
       do
         local res_2_auto
         do
-          local function _391_()
+          local function _406_()
             if initial_invoc_3f then
               return opts.exit_after_idle_msecs.labeled
             else
               return nil
             end
           end
-          res_2_auto = get_input(_391_())
+          res_2_auto = get_input(_406_())
         end
         hl:cleanup()
-        _390_ = res_2_auto
+        _405_ = res_2_auto
       end
-      if (nil ~= _390_) then
-        local input = _390_
+      if (nil ~= _405_) then
+        local input = _405_
         if (sublist["autojump?"] and opts.labels and not empty_3f(opts.labels)) then
           return {input, 0}
         elseif (((input == next_group_key) or (input == prev_group_key)) and not instant_repeat_3f) then
@@ -1975,19 +2036,19 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
           local num_of_groups = ceil((#sublist / #labels))
           local max_offset = dec(num_of_groups)
           local group_offset_2a
-          local _393_
+          local _408_
           do
-            local _392_ = input
-            if (_392_ == next_group_key) then
-              _393_ = inc
+            local _407_ = input
+            if (_407_ == next_group_key) then
+              _408_ = inc
             elseif true then
-              local _ = _392_
-              _393_ = dec
+              local _ = _407_
+              _408_ = dec
             else
-              _393_ = nil
+              _408_ = nil
             end
           end
-          group_offset_2a = clamp(_393_(group_offset), 0, max_offset)
+          group_offset_2a = clamp(_408_(group_offset), 0, max_offset)
           set_label_states_for_sublist(sublist, {["group-offset"] = group_offset_2a})
           return recur(group_offset_2a)
         else
@@ -2016,9 +2077,9 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     vim.cmd("redraw")
   else
   end
-  local _402_ = get_first_input()
-  if (nil ~= _402_) then
-    local in1 = _402_
+  local _417_ = get_first_input()
+  if (nil ~= _417_) then
+    local in1 = _417_
     local _
     to_eol_3f = (in1 == "\13")
     _ = nil
@@ -2034,16 +2095,16 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     else
       prev_in2 = nil
     end
-    local _404_
-    local function _406_()
-      local t_405_ = instant_state
-      if (nil ~= t_405_) then
-        t_405_ = (t_405_).sublist
+    local _419_
+    local function _421_()
+      local t_420_ = instant_state
+      if (nil ~= t_420_) then
+        t_420_ = (t_420_).sublist
       else
       end
-      return t_405_
+      return t_420_
     end
-    local function _408_()
+    local function _423_()
       if change_operation_3f() then
         handle_interrupted_change_op_21()
       else
@@ -2055,11 +2116,11 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
       doau_when_exists("LightspeedLeave")
       return nil
     end
-    _404_ = (_406_() or get_targets(in1, reverse_3f0) or _408_())
-    if ((_G.type(_404_) == "table") and ((_G.type((_404_)[1]) == "table") and ((_G.type(((_404_)[1]).pair) == "table") and true and (nil ~= (((_404_)[1]).pair)[2]))) and ((_404_)[2] == nil)) then
-      local _0 = (((_404_)[1]).pair)[1]
-      local ch2 = (((_404_)[1]).pair)[2]
-      local only = (_404_)[1]
+    _419_ = (_421_() or get_targets(in1, reverse_3f0) or _423_())
+    if ((_G.type(_419_) == "table") and ((_G.type((_419_)[1]) == "table") and ((_G.type(((_419_)[1]).pair) == "table") and true and (nil ~= (((_419_)[1]).pair)[2]))) and ((_419_)[2] == nil)) then
+      local _0 = (((_419_)[1]).pair)[1]
+      local ch2 = (((_419_)[1]).pair)[2]
+      local only = (_419_)[1]
       if (new_search_3f or (ch2 == prev_in2)) then
         do
           if dot_repeatable_op_3f then
@@ -2093,20 +2154,20 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         doau_when_exists("LightspeedLeave")
         return nil
       end
-    elseif (nil ~= _404_) then
-      local targets = _404_
+    elseif (nil ~= _419_) then
+      local targets = _419_
       if not instant_repeat_3f then
-        local _414_ = targets
-        populate_sublists(_414_)
-        set_labels(_414_, to_eol_3f)
-        set_label_states(_414_)
+        local _429_ = targets
+        populate_sublists(_429_)
+        set_labels(_429_, to_eol_3f)
+        set_label_states(_429_)
       else
       end
       if (new_search_3f and not to_eol_3f) then
         do
-          local _416_ = targets
-          set_shortcuts_and_populate_shortcuts_map(_416_)
-          set_beacons(_416_, {["repeat"] = nil})
+          local _431_ = targets
+          set_shortcuts_and_populate_shortcuts_map(_431_)
+          set_beacons(_431_, {["repeat"] = nil})
         end
         if (opts.grey_out_search_area and not (cold_repeat_3f or instant_repeat_3f or to_eol_3f)) then
           grey_out_search_area(reverse_3f0)
@@ -2119,15 +2180,15 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         vim.cmd("redraw")
       else
       end
-      local _419_
-      local function _420_()
+      local _434_
+      local function _435_()
         if to_eol_3f then
           return ""
         else
           return nil
         end
       end
-      local function _421_()
+      local function _436_()
         local res_2_auto
         do
           res_2_auto = get_input()
@@ -2135,7 +2196,7 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         hl:cleanup()
         return res_2_auto
       end
-      local function _422_()
+      local function _437_()
         if change_operation_3f() then
           handle_interrupted_change_op_21()
         else
@@ -2146,22 +2207,22 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         doau_when_exists("LightspeedLeave")
         return nil
       end
-      _419_ = (prev_in2 or _420_() or _421_() or _422_())
-      if (nil ~= _419_) then
-        local in2 = _419_
-        local _424_
+      _434_ = (prev_in2 or _435_() or _436_() or _437_())
+      if (nil ~= _434_) then
+        local in2 = _434_
+        local _439_
         do
-          local t_425_ = targets.shortcuts
-          if (nil ~= t_425_) then
-            t_425_ = (t_425_)[in2]
+          local t_440_ = targets.shortcuts
+          if (nil ~= t_440_) then
+            t_440_ = (t_440_)[in2]
           else
           end
-          _424_ = t_425_
+          _439_ = t_440_
         end
-        if ((_G.type(_424_) == "table") and ((_G.type((_424_).pair) == "table") and true and (nil ~= ((_424_).pair)[2]))) then
-          local _0 = ((_424_).pair)[1]
-          local ch2 = ((_424_).pair)[2]
-          local shortcut = _424_
+        if ((_G.type(_439_) == "table") and ((_G.type((_439_).pair) == "table") and true and (nil ~= ((_439_).pair)[2]))) then
+          local _0 = ((_439_).pair)[1]
+          local ch2 = ((_439_).pair)[2]
+          local shortcut = _439_
           do
             if dot_repeatable_op_3f then
               set_dot_repeat(replace_keycodes(get_plug_key("sx", reverse_3f0, x_mode_3f0, "dot")))
@@ -2174,19 +2235,19 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
           doau_when_exists("LightspeedLeave")
           return nil
         elseif true then
-          local _0 = _424_
+          local _0 = _439_
           to_pre_eol_3f = (in2 == "\13")
           update_state({cold = {in2 = in2}})
-          local _428_
-          local function _430_()
-            local t_429_ = instant_state
-            if (nil ~= t_429_) then
-              t_429_ = (t_429_).sublist
+          local _443_
+          local function _445_()
+            local t_444_ = instant_state
+            if (nil ~= t_444_) then
+              t_444_ = (t_444_).sublist
             else
             end
-            return t_429_
+            return t_444_
           end
-          local function _432_()
+          local function _447_()
             if change_operation_3f() then
               handle_interrupted_change_op_21()
             else
@@ -2198,9 +2259,9 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
             doau_when_exists("LightspeedLeave")
             return nil
           end
-          _428_ = (_430_() or get_sublist(targets, in2) or _432_())
-          if ((_G.type(_428_) == "table") and (nil ~= (_428_)[1]) and ((_428_)[2] == nil)) then
-            local only = (_428_)[1]
+          _443_ = (_445_() or get_sublist(targets, in2) or _447_())
+          if ((_G.type(_443_) == "table") and (nil ~= (_443_)[1]) and ((_443_)[2] == nil)) then
+            local only = (_443_)[1]
             do
               if dot_repeatable_op_3f then
                 set_dot_repeat(replace_keycodes(get_plug_key("sx", reverse_3f0, x_mode_3f0, "dot")))
@@ -2212,27 +2273,27 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
             doau_when_exists("LightspeedSxLeave")
             doau_when_exists("LightspeedLeave")
             return nil
-          elseif ((_G.type(_428_) == "table") and (nil ~= (_428_)[1])) then
-            local first = (_428_)[1]
-            local sublist = _428_
+          elseif ((_G.type(_443_) == "table") and (nil ~= (_443_)[1])) then
+            local first = (_443_)[1]
+            local sublist = _443_
             local autojump_3f = sublist["autojump?"]
             local curr_idx
-            local function _436_()
-              local t_435_ = instant_state
-              if (nil ~= t_435_) then
-                t_435_ = (t_435_).idx
+            local function _451_()
+              local t_450_ = instant_state
+              if (nil ~= t_450_) then
+                t_450_ = (t_450_).idx
               else
               end
-              return t_435_
+              return t_450_
             end
-            local function _438_()
+            local function _453_()
               if autojump_3f then
                 return 1
               else
                 return 0
               end
             end
-            curr_idx = (_436_() or _438_())
+            curr_idx = (_451_() or _453_())
             local from_reverse_cold_repeat_3f
             if instant_repeat_3f then
               from_reverse_cold_repeat_3f = instant_state["from-reverse-cold-repeat?"]
@@ -2243,15 +2304,15 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
               jump_to_21(first.pos)
             else
             end
-            local _441_
-            local function _442_()
+            local _456_
+            local function _457_()
               if (dot_repeat_3f and self.state.dot.in3) then
                 return {self.state.dot.in3, 0}
               else
                 return nil
               end
             end
-            local function _443_()
+            local function _458_()
               if change_operation_3f() then
                 handle_interrupted_change_op_21()
               else
@@ -2262,24 +2323,24 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
               doau_when_exists("LightspeedLeave")
               return nil
             end
-            _441_ = (_442_() or get_last_input(sublist, inc(curr_idx)) or _443_())
-            if ((_G.type(_441_) == "table") and (nil ~= (_441_)[1]) and (nil ~= (_441_)[2])) then
-              local in3 = (_441_)[1]
-              local group_offset = (_441_)[2]
-              local _445_
+            _456_ = (_457_() or get_last_input(sublist, inc(curr_idx)) or _458_())
+            if ((_G.type(_456_) == "table") and (nil ~= (_456_)[1]) and (nil ~= (_456_)[2])) then
+              local in3 = (_456_)[1]
+              local group_offset = (_456_)[2]
+              local _460_
               if not (op_mode_3f or (group_offset > 0)) then
-                _445_ = get_repeat_action(in3, "sx", x_mode_3f0, instant_repeat_3f, from_reverse_cold_repeat_3f)
+                _460_ = get_repeat_action(in3, "sx", x_mode_3f0, instant_repeat_3f, from_reverse_cold_repeat_3f)
               else
-                _445_ = nil
+                _460_ = nil
               end
-              if (nil ~= _445_) then
-                local action = _445_
+              if (nil ~= _460_) then
+                local action = _460_
                 local idx
                 do
-                  local _447_ = action
-                  if (_447_ == "repeat") then
+                  local _462_ = action
+                  if (_462_ == "repeat") then
                     idx = min(inc(curr_idx), #targets)
-                  elseif (_447_ == "revert") then
+                  elseif (_462_ == "revert") then
                     idx = max(dec(curr_idx), 1)
                   else
                     idx = nil
@@ -2288,29 +2349,29 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
                 jump_to_21(sublist[idx].pos)
                 return sx:go(reverse_3f0, x_mode_3f0, {in1 = in1, in2 = in2, sublist = sublist, idx = idx, ["from-reverse-cold-repeat?"] = from_reverse_cold_repeat_3f})
               elseif true then
-                local _1 = _445_
-                local _449_ = get_target_with_active_primary_label(sublist, in3)
-                if (nil ~= _449_) then
-                  local target = _449_
+                local _1 = _460_
+                local _464_ = get_target_with_active_primary_label(sublist, in3)
+                if (nil ~= _464_) then
+                  local target = _464_
                   do
                     if dot_repeatable_op_3f then
                       set_dot_repeat(replace_keycodes(get_plug_key("sx", reverse_3f0, x_mode_3f0, "dot")))
                     else
                     end
-                    local _451_
+                    local _466_
                     if (group_offset > 0) then
-                      _451_ = nil
+                      _466_ = nil
                     else
-                      _451_ = in3
+                      _466_ = in3
                     end
-                    update_state({dot = {in2 = in2, in3 = _451_}})
+                    update_state({dot = {in2 = in2, in3 = _466_}})
                     jump_to_21(target.pos)
                   end
                   doau_when_exists("LightspeedSxLeave")
                   doau_when_exists("LightspeedLeave")
                   return nil
                 elseif true then
-                  local _2 = _449_
+                  local _2 = _464_
                   if autojump_3f then
                     do
                       if dot_repeatable_op_3f then
@@ -2362,26 +2423,26 @@ local temporary_editor_opts = {["vim.wo.conceallevel"] = 0, ["vim.wo.scrolloff"]
 local saved_editor_opts = {}
 local function save_editor_opts()
   for opt, _ in pairs(temporary_editor_opts) do
-    local _let_464_ = vim.split(opt, ".", true)
-    local _0 = _let_464_[1]
-    local scope = _let_464_[2]
-    local name = _let_464_[3]
-    local _465_
+    local _let_479_ = vim.split(opt, ".", true)
+    local _0 = _let_479_[1]
+    local scope = _let_479_[2]
+    local name = _let_479_[3]
+    local _480_
     if (opt == "vim.wo.scrolloff") then
-      _465_ = api.nvim_eval("&l:scrolloff")
+      _480_ = api.nvim_eval("&l:scrolloff")
     else
-      _465_ = _G.vim[scope][name]
+      _480_ = _G.vim[scope][name]
     end
-    saved_editor_opts[opt] = _465_
+    saved_editor_opts[opt] = _480_
   end
   return nil
 end
 local function set_editor_opts(opts0)
   for opt, val in pairs(opts0) do
-    local _let_467_ = vim.split(opt, ".", true)
-    local _ = _let_467_[1]
-    local scope = _let_467_[2]
-    local name = _let_467_[3]
+    local _let_482_ = vim.split(opt, ".", true)
+    local _ = _let_482_[1]
+    local scope = _let_482_[2]
+    local name = _let_482_[3]
     _G.vim[scope][name] = val
   end
   return nil
@@ -2392,40 +2453,7 @@ end
 local function restore_editor_opts()
   return set_editor_opts(saved_editor_opts)
 end
-local function set_plug_keys()
-  local plug_keys = {{"<Plug>Lightspeed_s", "sx:go(false)"}, {"<Plug>Lightspeed_S", "sx:go(true)"}, {"<Plug>Lightspeed_x", "sx:go(false, true)"}, {"<Plug>Lightspeed_X", "sx:go(true, true)"}, {"<Plug>Lightspeed_f", "ft:go(false)"}, {"<Plug>Lightspeed_F", "ft:go(true)"}, {"<Plug>Lightspeed_t", "ft:go(false, true)"}, {"<Plug>Lightspeed_T", "ft:go(true, true)"}, {"<Plug>Lightspeed_;_sx", "sx:go(false, nil, 'cold')"}, {"<Plug>Lightspeed_,_sx", "sx:go(true, nil, 'cold')"}, {"<Plug>Lightspeed_;_ft", "ft:go(false, nil, 'cold')"}, {"<Plug>Lightspeed_,_ft", "ft:go(true, nil, 'cold')"}}
-  for _, _468_ in ipairs(plug_keys) do
-    local _each_469_ = _468_
-    local lhs = _each_469_[1]
-    local rhs_call = _each_469_[2]
-    for _0, mode in ipairs({"n", "x", "o"}) do
-      api.nvim_set_keymap(mode, lhs, ("<cmd>lua require'lightspeed'." .. rhs_call .. "<cr>"), {noremap = true, silent = true})
-    end
-  end
-  for _, _470_ in ipairs({{"<Plug>Lightspeed_dotrepeat_s", "sx:go(false, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_S", "sx:go(true, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_x", "sx:go(false, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_X", "sx:go(true, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_f", "ft:go(false, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_F", "ft:go(true, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_t", "ft:go(false, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_T", "ft:go(true, true, 'dot')"}}) do
-    local _each_471_ = _470_
-    local lhs = _each_471_[1]
-    local rhs_call = _each_471_[2]
-    api.nvim_set_keymap("o", lhs, ("<cmd>lua require'lightspeed'." .. rhs_call .. "<cr>"), {noremap = true, silent = true})
-  end
-  return nil
-end
-local function set_default_keymaps()
-  local default_keymaps = {{"n", "s", "<Plug>Lightspeed_s"}, {"n", "S", "<Plug>Lightspeed_S"}, {"x", "s", "<Plug>Lightspeed_s"}, {"x", "S", "<Plug>Lightspeed_S"}, {"o", "z", "<Plug>Lightspeed_s"}, {"o", "Z", "<Plug>Lightspeed_S"}, {"o", "x", "<Plug>Lightspeed_x"}, {"o", "X", "<Plug>Lightspeed_X"}, {"n", "f", "<Plug>Lightspeed_f"}, {"n", "F", "<Plug>Lightspeed_F"}, {"x", "f", "<Plug>Lightspeed_f"}, {"x", "F", "<Plug>Lightspeed_F"}, {"o", "f", "<Plug>Lightspeed_f"}, {"o", "F", "<Plug>Lightspeed_F"}, {"n", "t", "<Plug>Lightspeed_t"}, {"n", "T", "<Plug>Lightspeed_T"}, {"x", "t", "<Plug>Lightspeed_t"}, {"x", "T", "<Plug>Lightspeed_T"}, {"o", "t", "<Plug>Lightspeed_t"}, {"o", "T", "<Plug>Lightspeed_T"}, {"n", ";", "<Plug>Lightspeed_;_ft"}, {"x", ";", "<Plug>Lightspeed_;_ft"}, {"o", ";", "<Plug>Lightspeed_;_ft"}, {"n", ",", "<Plug>Lightspeed_,_ft"}, {"x", ",", "<Plug>Lightspeed_,_ft"}, {"o", ",", "<Plug>Lightspeed_,_ft"}}
-  for _, _472_ in ipairs(default_keymaps) do
-    local _each_473_ = _472_
-    local mode = _each_473_[1]
-    local lhs = _each_473_[2]
-    local rhs = _each_473_[3]
-    if ((vim.fn.mapcheck(lhs, mode) == "") and (vim.fn.hasmapto(rhs, mode) == 0)) then
-      api.nvim_set_keymap(mode, lhs, rhs, {silent = true})
-    else
-    end
-  end
-  return nil
-end
 init_highlight()
-set_plug_keys()
 vim.cmd("augroup lightspeed_reinit_highlight\n   autocmd!\n   autocmd ColorScheme * lua require'lightspeed'.init_highlight()\n   augroup end")
 vim.cmd("augroup lightspeed_editor_opts\n   autocmd!\n   autocmd User LightspeedEnter lua require'lightspeed'.save_editor_opts(); require'lightspeed'.set_temporary_editor_opts()\n   autocmd User LightspeedLeave lua require'lightspeed'.restore_editor_opts()\n   augroup end")
 return {opts = opts, setup = setup, ft = ft, sx = sx, save_editor_opts = save_editor_opts, set_temporary_editor_opts = set_temporary_editor_opts, restore_editor_opts = restore_editor_opts, init_highlight = init_highlight, set_default_keymaps = set_default_keymaps}

--- a/lua/lightspeed.lua
+++ b/lua/lightspeed.lua
@@ -941,7 +941,7 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       if to_eol_3f then
         pattern = "\\n"
       else
-        pattern = ("\\V" .. in1:gsub("\\", "\\\\"))
+        pattern = ("\\V\\C" .. in1:gsub("\\", "\\\\"))
       end
       local limit = (count0 + get_num_of_matches_to_be_highlighted())
       for _221_ in onscreen_match_positions(pattern, reverse_3f0, {["ft-search?"] = true, limit = limit}) do
@@ -1851,9 +1851,9 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     end
     _410_ = (_412_() or get_targets(in1, reverse_3f0) or _414_())
     if ((type(_410_) == "table") and ((type((_410_)[1]) == "table") and ((type(((_410_)[1]).pair) == "table") and true and (nil ~= (((_410_)[1]).pair)[2]))) and ((_410_)[2] == nil)) then
-      local only = (_410_)[1]
       local _0 = (((_410_)[1]).pair)[1]
       local ch2 = (((_410_)[1]).pair)[2]
+      local only = (_410_)[1]
       if (new_search_3f or (ch2 == prev_in2)) then
         do
           if dot_repeatable_op_3f then
@@ -1943,9 +1943,9 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
           _430_ = t_431_
         end
         if ((type(_430_) == "table") and ((type((_430_).pair) == "table") and true and (nil ~= ((_430_).pair)[2]))) then
-          local shortcut = _430_
           local _0 = ((_430_).pair)[1]
           local ch2 = ((_430_).pair)[2]
+          local shortcut = _430_
           do
             if dot_repeatable_op_3f then
               set_dot_repeat(replace_keycodes(get_plug_key("sx", reverse_3f0, x_mode_3f0, "dot")))

--- a/lua/lightspeed.lua
+++ b/lua/lightspeed.lua
@@ -18,6 +18,8 @@ local function clamp(val, min0, max0)
     return max0
   elseif "else" then
     return val
+  else
+    return nil
   end
 end
 local function last(tbl)
@@ -37,13 +39,17 @@ local function get_motion_force(mode)
   if mode:match("o") then
     _2_ = mode:sub(-1)
   else
-  _2_ = nil
+    _2_ = nil
   end
   if (nil ~= _2_) then
     local last_ch = _2_
     if ((last_ch == _3cctrl_v_3e) or (last_ch == "V") or (last_ch == "v")) then
       return last_ch
+    else
+      return nil
     end
+  else
+    return nil
   end
 end
 local function operator_pending_mode_3f()
@@ -75,6 +81,8 @@ local function char_at_pos(_10_, _12_)
   local char_nr = vim.fn.strgetchar(line_str, (char_idx + (char_offset or 0)))
   if (char_nr ~= -1) then
     return vim.fn.nr2char(char_nr)
+  else
+    return nil
   end
 end
 local function leftmost_editable_wincol()
@@ -102,6 +110,8 @@ local function get_fold_edge(lnum, reverse_3f)
   elseif (nil ~= _16_) then
     local fold_edge = _16_
     return fold_edge
+  else
+    return nil
   end
 end
 local function maparg_expr(name, mode)
@@ -117,22 +127,28 @@ local opts
 do
   local safe_labels = {"s", "f", "n", "u", "t", "/", "F", "L", "N", "H", "G", "M", "U", "T", "?", "Z"}
   local labels = {"s", "f", "n", "j", "k", "l", "o", "i", "w", "e", "h", "g", "u", "t", "m", "v", "c", "a", ".", "z", "/", "F", "L", "N", "H", "G", "M", "U", "T", "?", "Z"}
-  opts = {cycle_group_bwd_key = "<tab>", cycle_group_fwd_key = "<space>", exit_after_idle_msecs = {labeled = nil, unlabeled = 1000}, grey_out_search_area = true, highlight_unique_chars = true, ignore_case = false, jump_on_partial_input_safety_timeout = 400, labels = labels, limit_ft_matches = 4, match_only_the_start_of_same_char_seqs = true, repeat_ft_with_target_char = false, safe_labels = safe_labels, substitute_chars = {["\13"] = "\194\172"}}
+  opts = {ignore_case = false, exit_after_idle_msecs = {labeled = nil, unlabeled = 1000}, ["disable-default-mappings"] = true, grey_out_search_area = true, highlight_unique_chars = true, match_only_the_start_of_same_char_seqs = true, jump_on_partial_input_safety_timeout = 400, substitute_chars = {["\13"] = "\194\172"}, safe_labels = safe_labels, labels = labels, cycle_group_fwd_key = "<space>", cycle_group_bwd_key = "<tab>", limit_ft_matches = 4, repeat_ft_with_target_char = false}
 end
 local deprecated_opts = {"jump_to_first_match", "instant_repeat_fwd_key", "instant_repeat_bwd_key", "x_mode_prefix_key", "full_inclusive_prefix_key"}
 local function get_deprec_msg(arg_fields)
   local msg = {{"ligthspeed.nvim\n", "Question"}, {"You are trying to set or access deprecated fields in the "}, {"opts", "Visual"}, {" table:\n\n"}}
   local field_names
   do
-    local tbl_12_auto = {}
+    local tbl_15_auto = {}
+    local i_16_auto = #tbl_15_auto
     for _, field in ipairs(arg_fields) do
-      tbl_12_auto[(#tbl_12_auto + 1)] = {("\9" .. field .. "\n")}
+      local val_17_auto = {("\9" .. field .. "\n")}
+      if (nil ~= val_17_auto) then
+        i_16_auto = (i_16_auto + 1)
+        do end (tbl_15_auto)[i_16_auto] = val_17_auto
+      else
+      end
     end
-    field_names = tbl_12_auto
+    field_names = tbl_15_auto
   end
   local msg_for_instant_repeat_keys = {{"There are dedicated "}, {"<Plug>", "Visual"}, {" keys available for native-like "}, {";", "Visual"}, {" and "}, {",", "Visual"}, {" functionality now, "}, {"that can also be used for instant repeat only, if you prefer. See "}, {":h lightspeed-custom-mappings", "Visual"}, {"."}}
   local msg_for_x_prefix = {{"Use "}, {"<Plug>Lightspeed_x", "Visual"}, {" and "}, {"<Plug>Lightspeed_X", "Visual"}, {" instead."}}
-  local spec_messages = {full_inclusive_prefix_key = msg_for_x_prefix, instant_repeat_bwd_key = msg_for_instant_repeat_keys, instant_repeat_fwd_key = msg_for_instant_repeat_keys, jump_to_first_match = {{"The plugin implements \"smart\" auto-jump now, that you can fine-tune via "}, {"opts.labels", "Visual"}, {" and "}, {"opts.safe_labels", "Visual"}, {". See "}, {":h lightspeed-config", "Visual"}, {" for details."}}, x_mode_prefix_key = msg_for_x_prefix}
+  local spec_messages = {jump_to_first_match = {{"The plugin implements \"smart\" auto-jump now, that you can fine-tune via "}, {"opts.labels", "Visual"}, {" and "}, {"opts.safe_labels", "Visual"}, {". See "}, {":h lightspeed-config", "Visual"}, {" for details."}}, instant_repeat_fwd_key = msg_for_instant_repeat_keys, instant_repeat_bwd_key = msg_for_instant_repeat_keys, x_mode_prefix_key = msg_for_x_prefix, full_inclusive_prefix_key = msg_for_x_prefix}
   for _, field_name_chunk in ipairs(field_names) do
     table.insert(msg, field_name_chunk)
   end
@@ -144,18 +160,21 @@ local function get_deprec_msg(arg_fields)
         table.insert(msg, chunk)
       end
       table.insert(msg, {"\n\n"})
+    else
     end
   end
   return msg
 end
 do
   local guard
-  local function _22_(t, k)
+  local function _23_(t, k)
     if contains_3f(deprecated_opts, k) then
       return api.nvim_echo(get_deprec_msg({k}), true, {})
+    else
+      return nil
     end
   end
-  guard = _22_
+  guard = _23_
   setmetatable(opts, {__index = guard, __newindex = guard})
 end
 local function normalize_opts(opts0)
@@ -164,209 +183,243 @@ local function normalize_opts(opts0)
     if contains_3f(deprecated_opts, k) then
       table.insert(deprecated_arg_opts, k)
       do end (opts0)[k] = nil
+    else
     end
   end
   if not empty_3f(deprecated_arg_opts) then
     api.nvim_echo(get_deprec_msg(deprecated_arg_opts), true, {})
+  else
   end
   return opts0
 end
 local function setup(user_opts)
+  if not ("disable-default-mappings")(user_opts) then
+    __fnl_global__set_2ddefault_2dkeymaps()
+  else
+  end
   opts = setmetatable(normalize_opts(user_opts), {__index = opts})
   return nil
 end
 local hl
-local function _26_(self, hl_group, line, startcol, endcol)
+local function _28_(self, hl_group, line, startcol, endcol)
   return api.nvim_buf_add_highlight(0, self.ns, hl_group, line, startcol, endcol)
 end
-local function _27_(self, line, col, opts0)
+local function _29_(self, line, col, opts0)
   return api.nvim_buf_set_extmark(0, self.ns, line, col, opts0)
 end
-local function _28_(self)
+local function _30_(self)
   return api.nvim_buf_clear_namespace(0, self.ns, 0, -1)
 end
-hl = {["add-hl"] = _26_, ["set-extmark"] = _27_, cleanup = _28_, group = {["label-distant"] = "LightspeedLabelDistant", ["label-distant-overlapped"] = "LightspeedLabelDistantOverlapped", ["label-overlapped"] = "LightspeedLabelOverlapped", ["masked-ch"] = "LightspeedMaskedChar", ["one-char-match"] = "LightspeedOneCharMatch", ["pending-op-area"] = "LightspeedPendingOpArea", ["shortcut-overlapped"] = "LightspeedShortcutOverlapped", ["unique-ch"] = "LightspeedUniqueChar", ["unlabeled-match"] = "LightspeedUnlabeledMatch", cursor = "LightspeedCursor", greywash = "LightspeedGreyWash", label = "LightspeedLabel", shortcut = "LightspeedShortcut"}, ns = api.nvim_create_namespace("")}
+hl = {group = {label = "LightspeedLabel", ["label-distant"] = "LightspeedLabelDistant", ["label-overlapped"] = "LightspeedLabelOverlapped", ["label-distant-overlapped"] = "LightspeedLabelDistantOverlapped", shortcut = "LightspeedShortcut", ["shortcut-overlapped"] = "LightspeedShortcutOverlapped", ["masked-ch"] = "LightspeedMaskedChar", ["unlabeled-match"] = "LightspeedUnlabeledMatch", ["one-char-match"] = "LightspeedOneCharMatch", ["unique-ch"] = "LightspeedUniqueChar", ["pending-op-area"] = "LightspeedPendingOpArea", greywash = "LightspeedGreyWash", cursor = "LightspeedCursor"}, ns = api.nvim_create_namespace(""), ["add-hl"] = _28_, ["set-extmark"] = _29_, cleanup = _30_}
 local function init_highlight(force_3f)
   local bg = vim.o.background
   local groupdefs
-  local _30_
+  local _32_
   do
-    local _29_ = bg
-    if (_29_ == "light") then
-      _30_ = "#f02077"
+    local _31_ = bg
+    if (_31_ == "light") then
+      _32_ = "#f02077"
+    elseif true then
+      local _ = _31_
+      _32_ = "#ff2f87"
     else
-      local _ = _29_
-      _30_ = "#ff2f87"
+      _32_ = nil
     end
   end
-  local _35_
+  local _37_
   do
-    local _34_ = bg
-    if (_34_ == "light") then
-      _35_ = "#ff4090"
+    local _36_ = bg
+    if (_36_ == "light") then
+      _37_ = "#ff4090"
+    elseif true then
+      local _ = _36_
+      _37_ = "#e01067"
     else
-      local _ = _34_
-      _35_ = "#e01067"
+      _37_ = nil
     end
   end
-  local _40_
+  local _42_
   do
-    local _39_ = bg
-    if (_39_ == "light") then
-      _40_ = "Blue"
+    local _41_ = bg
+    if (_41_ == "light") then
+      _42_ = "#399d9f"
+    elseif true then
+      local _ = _41_
+      _42_ = "#99ddff"
     else
-      local _ = _39_
-      _40_ = "Cyan"
+      _42_ = nil
     end
   end
-  local _45_
+  local _47_
   do
-    local _44_ = bg
-    if (_44_ == "light") then
-      _45_ = "#399d9f"
+    local _46_ = bg
+    if (_46_ == "light") then
+      _47_ = "Blue"
+    elseif true then
+      local _ = _46_
+      _47_ = "Cyan"
     else
-      local _ = _44_
-      _45_ = "#99ddff"
+      _47_ = nil
     end
   end
-  local _50_
+  local _52_
   do
-    local _49_ = bg
-    if (_49_ == "light") then
-      _50_ = "Cyan"
+    local _51_ = bg
+    if (_51_ == "light") then
+      _52_ = "#59bdbf"
+    elseif true then
+      local _ = _51_
+      _52_ = "#79bddf"
     else
-      local _ = _49_
-      _50_ = "Blue"
+      _52_ = nil
     end
   end
-  local _55_
+  local _57_
   do
-    local _54_ = bg
-    if (_54_ == "light") then
-      _55_ = "#59bdbf"
+    local _56_ = bg
+    if (_56_ == "light") then
+      _57_ = "Cyan"
+    elseif true then
+      local _ = _56_
+      _57_ = "Blue"
     else
-      local _ = _54_
-      _55_ = "#79bddf"
+      _57_ = nil
     end
   end
-  local _60_
+  local _62_
   do
-    local _59_ = bg
-    if (_59_ == "light") then
-      _60_ = "#cc9999"
+    local _61_ = bg
+    if (_61_ == "light") then
+      _62_ = "#cc9999"
+    elseif true then
+      local _ = _61_
+      _62_ = "#b38080"
     else
-      local _ = _59_
-      _60_ = "#b38080"
+      _62_ = nil
     end
   end
-  local _65_
+  local _67_
   do
-    local _64_ = bg
-    if (_64_ == "light") then
-      _65_ = "Black"
+    local _66_ = bg
+    if (_66_ == "light") then
+      _67_ = "#272020"
+    elseif true then
+      local _ = _66_
+      _67_ = "#f3ecec"
     else
-      local _ = _64_
-      _65_ = "White"
+      _67_ = nil
     end
   end
-  local _70_
+  local _72_
   do
-    local _69_ = bg
-    if (_69_ == "light") then
-      _70_ = "#272020"
+    local _71_ = bg
+    if (_71_ == "light") then
+      _72_ = "Black"
+    elseif true then
+      local _ = _71_
+      _72_ = "White"
     else
-      local _ = _69_
-      _70_ = "#f3ecec"
+      _72_ = nil
     end
   end
-  groupdefs = {{hl.group.label, {cterm = "bold,underline", ctermbg = "NONE", ctermfg = "Red", gui = "bold,underline", guibg = "NONE", guifg = _30_}}, {hl.group["label-overlapped"], {cterm = "underline", ctermbg = "NONE", ctermfg = "Magenta", gui = "underline", guibg = "NONE", guifg = _35_}}, {hl.group["label-distant"], {cterm = "bold,underline", ctermbg = "NONE", ctermfg = _40_, gui = "bold,underline", guibg = "NONE", guifg = _45_}}, {hl.group["label-distant-overlapped"], {cterm = "underline", ctermfg = _50_, gui = "underline", guifg = _55_}}, {hl.group.shortcut, {cterm = "bold,underline", ctermbg = "Red", ctermfg = "White", gui = "bold,underline", guibg = "#f00077", guifg = "#ffffff"}}, {hl.group["one-char-match"], {cterm = "bold", ctermbg = "Red", ctermfg = "White", gui = "bold", guibg = "#f00077", guifg = "#ffffff"}}, {hl.group["masked-ch"], {cterm = "NONE", ctermbg = "NONE", ctermfg = "DarkGrey", gui = "NONE", guibg = "NONE", guifg = _60_}}, {hl.group["unlabeled-match"], {cterm = "bold", ctermbg = "NONE", ctermfg = _65_, gui = "bold", guibg = "NONE", guifg = _70_}}, {hl.group["pending-op-area"], {ctermbg = "Red", ctermfg = "White", guibg = "#f00077", guifg = "#ffffff"}}, {hl.group.greywash, {cterm = "NONE", ctermbg = "NONE", ctermfg = "Grey", gui = "NONE", guibg = "NONE", guifg = "#777777"}}}
-  for _, _74_ in ipairs(groupdefs) do
-    local _each_75_ = _74_
-    local group = _each_75_[1]
-    local attrs = _each_75_[2]
+  groupdefs = {{hl.group.label, {guifg = _32_, ctermfg = "Red", guibg = "NONE", ctermbg = "NONE", gui = "bold,underline", cterm = "bold,underline"}}, {hl.group["label-overlapped"], {guifg = _37_, ctermfg = "Magenta", guibg = "NONE", ctermbg = "NONE", gui = "underline", cterm = "underline"}}, {hl.group["label-distant"], {guifg = _42_, ctermfg = _47_, guibg = "NONE", ctermbg = "NONE", gui = "bold,underline", cterm = "bold,underline"}}, {hl.group["label-distant-overlapped"], {guifg = _52_, ctermfg = _57_, gui = "underline", cterm = "underline"}}, {hl.group.shortcut, {guibg = "#f00077", ctermbg = "Red", guifg = "#ffffff", ctermfg = "White", gui = "bold,underline", cterm = "bold,underline"}}, {hl.group["one-char-match"], {guibg = "#f00077", ctermbg = "Red", guifg = "#ffffff", ctermfg = "White", gui = "bold", cterm = "bold"}}, {hl.group["masked-ch"], {guifg = _62_, ctermfg = "DarkGrey", guibg = "NONE", ctermbg = "NONE", gui = "NONE", cterm = "NONE"}}, {hl.group["unlabeled-match"], {guifg = _67_, ctermfg = _72_, guibg = "NONE", ctermbg = "NONE", gui = "bold", cterm = "bold"}}, {hl.group["pending-op-area"], {guibg = "#f00077", ctermbg = "Red", guifg = "#ffffff", ctermfg = "White"}}, {hl.group.greywash, {guifg = "#777777", ctermfg = "Grey", guibg = "NONE", ctermbg = "NONE", gui = "NONE", cterm = "NONE"}}}
+  for _, _76_ in ipairs(groupdefs) do
+    local _each_77_ = _76_
+    local group = _each_77_[1]
+    local attrs = _each_77_[2]
     local attrs_str
-    local _76_
+    local _78_
     do
-      local tbl_12_auto = {}
+      local tbl_15_auto = {}
+      local i_16_auto = #tbl_15_auto
       for k, v in pairs(attrs) do
-        tbl_12_auto[(#tbl_12_auto + 1)] = (k .. "=" .. v)
+        local val_17_auto = (k .. "=" .. v)
+        if (nil ~= val_17_auto) then
+          i_16_auto = (i_16_auto + 1)
+          do end (tbl_15_auto)[i_16_auto] = val_17_auto
+        else
+        end
       end
-      _76_ = tbl_12_auto
+      _78_ = tbl_15_auto
     end
-    attrs_str = table.concat(_76_, " ")
-    local _77_
-    if force_3f then
-      _77_ = ""
-    else
-      _77_ = "default "
+    attrs_str = table.concat(_78_, " ")
+    local function _80_()
+      if force_3f then
+        return ""
+      else
+        return "default "
+      end
     end
-    vim.cmd(("highlight " .. _77_ .. group .. " " .. attrs_str))
+    vim.cmd(("highlight " .. _80_() .. group .. " " .. attrs_str))
   end
-  for _, _79_ in ipairs({{hl.group["unique-ch"], hl.group["unlabeled-match"]}, {hl.group["shortcut-overlapped"], hl.group.shortcut}, {hl.group.cursor, "Cursor"}}) do
-    local _each_80_ = _79_
-    local from_group = _each_80_[1]
-    local to_group = _each_80_[2]
-    local _81_
-    if force_3f then
-      _81_ = ""
-    else
-      _81_ = "default "
+  for _, _81_ in ipairs({{hl.group["unique-ch"], hl.group["unlabeled-match"]}, {hl.group["shortcut-overlapped"], hl.group.shortcut}, {hl.group.cursor, "Cursor"}}) do
+    local _each_82_ = _81_
+    local from_group = _each_82_[1]
+    local to_group = _each_82_[2]
+    local function _83_()
+      if force_3f then
+        return ""
+      else
+        return "default "
+      end
     end
-    vim.cmd(("highlight " .. _81_ .. "link " .. from_group .. " " .. to_group))
+    vim.cmd(("highlight " .. _83_() .. "link " .. from_group .. " " .. to_group))
   end
   return nil
 end
 local function grey_out_search_area(reverse_3f)
-  local _let_83_ = map(dec, get_cursor_pos())
-  local curline = _let_83_[1]
-  local curcol = _let_83_[2]
-  local _let_84_ = {dec(vim.fn.line("w0")), dec(vim.fn.line("w$"))}
-  local win_top = _let_84_[1]
-  local win_bot = _let_84_[2]
-  local function _86_()
+  local _let_84_ = map(dec, get_cursor_pos())
+  local curline = _let_84_[1]
+  local curcol = _let_84_[2]
+  local _let_85_ = {dec(vim.fn.line("w0")), dec(vim.fn.line("w$"))}
+  local win_top = _let_85_[1]
+  local win_bot = _let_85_[2]
+  local function _87_()
     if reverse_3f then
       return {{win_top, 0}, {curline, curcol}}
     else
       return {{curline, inc(curcol)}, {win_bot, -1}}
     end
   end
-  local _let_85_ = _86_()
-  local start = _let_85_[1]
-  local finish = _let_85_[2]
+  local _let_86_ = _87_()
+  local start = _let_86_[1]
+  local finish = _let_86_[2]
   return vim.highlight.range(0, hl.ns, hl.group.greywash, start, finish)
 end
-local function highlight_range(hl_group, _87_, _89_, _91_)
-  local _arg_88_ = _87_
-  local startline = _arg_88_[1]
-  local startcol = _arg_88_[2]
-  local start = _arg_88_
-  local _arg_90_ = _89_
-  local endline = _arg_90_[1]
-  local endcol = _arg_90_[2]
-  local _end = _arg_90_
-  local _arg_92_ = _91_
-  local inclusive_motion_3f = _arg_92_["inclusive-motion?"]
-  local motion_force = _arg_92_["motion-force"]
+local function highlight_range(hl_group, _88_, _90_, _92_)
+  local _arg_89_ = _88_
+  local startline = _arg_89_[1]
+  local startcol = _arg_89_[2]
+  local start = _arg_89_
+  local _arg_91_ = _90_
+  local endline = _arg_91_[1]
+  local endcol = _arg_91_[2]
+  local _end = _arg_91_
+  local _arg_93_ = _92_
+  local motion_force = _arg_93_["motion-force"]
+  local inclusive_motion_3f = _arg_93_["inclusive-motion?"]
   local hl_range
-  local function _93_(start0, _end0, end_inclusive_3f)
+  local function _94_(start0, _end0, end_inclusive_3f)
     return vim.highlight.range(0, hl.ns, hl_group, start0, _end0, nil, end_inclusive_3f)
   end
-  hl_range = _93_
-  local _94_ = motion_force
-  if (_94_ == _3cctrl_v_3e) then
-    local _let_95_ = {min(startcol, endcol), max(startcol, endcol)}
-    local startcol0 = _let_95_[1]
-    local endcol0 = _let_95_[2]
+  hl_range = _94_
+  local _95_ = motion_force
+  if (_95_ == _3cctrl_v_3e) then
+    local _let_96_ = {min(startcol, endcol), max(startcol, endcol)}
+    local startcol0 = _let_96_[1]
+    local endcol0 = _let_96_[2]
     for line = startline, endline do
       hl_range({line, startcol0}, {line, endcol0}, true)
     end
     return nil
-  elseif (_94_ == "V") then
+  elseif (_95_ == "V") then
     return hl_range({startline, 0}, {endline, -1})
-  elseif (_94_ == "v") then
+  elseif (_95_ == "v") then
     return hl_range(start, _end, not inclusive_motion_3f)
-  elseif (_94_ == nil) then
+  elseif (_95_ == nil) then
     return hl_range(start, _end, inclusive_motion_3f)
+  else
+    return nil
   end
 end
 local function echo_no_prev_search()
@@ -376,15 +429,17 @@ local function echo_not_found(s)
   return echo(("not found: " .. s))
 end
 local function push_cursor_21(direction)
-  local function _98_()
-    local _97_ = direction
-    if (_97_ == "fwd") then
+  local function _99_()
+    local _98_ = direction
+    if (_98_ == "fwd") then
       return "W"
-    elseif (_97_ == "bwd") then
+    elseif (_98_ == "bwd") then
       return "bW"
+    else
+      return nil
     end
   end
-  return vim.fn.search("\\_.", _98_())
+  return vim.fn.search("\\_.", _99_())
 end
 local function get_restore_virtualedit_autocmd()
   return ("autocmd " .. "CursorMoved,WinLeave,BufLeave,InsertEnter,CmdlineEnter,CmdwinEnter" .. " * ++once set virtualedit=" .. vim.o.virtualedit)
@@ -396,28 +451,30 @@ end
 local function cursor_before_eof_3f()
   return ((vim.fn.line(".") == vim.fn.line("$")) and (vim.fn.virtcol(".") == dec(vim.fn.virtcol("$"))))
 end
-local function jump_to_21_2a(target, _100_)
-  local _arg_101_ = _100_
-  local add_to_jumplist_3f = _arg_101_["add-to-jumplist?"]
-  local adjust = _arg_101_["adjust"]
-  local inclusive_motion_3f = _arg_101_["inclusive-motion?"]
-  local mode = _arg_101_["mode"]
-  local reverse_3f = _arg_101_["reverse?"]
+local function jump_to_21_2a(target, _101_)
+  local _arg_102_ = _101_
+  local mode = _arg_102_["mode"]
+  local reverse_3f = _arg_102_["reverse?"]
+  local inclusive_motion_3f = _arg_102_["inclusive-motion?"]
+  local add_to_jumplist_3f = _arg_102_["add-to-jumplist?"]
+  local adjust = _arg_102_["adjust"]
   local op_mode_3f = string.match(mode, "o")
   local motion_force = get_motion_force(mode)
   local restore_virtualedit_autocmd = get_restore_virtualedit_autocmd()
   if add_to_jumplist_3f then
     vim.cmd("norm! m`")
+  else
   end
   vim.fn.cursor(target)
   adjust()
   if not op_mode_3f then
     force_matchparen_refresh()
+  else
   end
   local adjusted_pos = get_cursor_pos()
   if (op_mode_3f and not reverse_3f and inclusive_motion_3f) then
-    local _104_ = motion_force
-    if (_104_ == nil) then
+    local _105_ = motion_force
+    if (_105_ == nil) then
       if not cursor_before_eof_3f() then
         push_cursor_21("fwd")
       else
@@ -425,55 +482,57 @@ local function jump_to_21_2a(target, _100_)
         vim.cmd("norm! l")
         vim.cmd(restore_virtualedit_autocmd)
       end
-    elseif (_104_ == "V") then
-    elseif (_104_ == _3cctrl_v_3e) then
-    elseif (_104_ == "v") then
+    elseif (_105_ == "V") then
+    elseif (_105_ == _3cctrl_v_3e) then
+    elseif (_105_ == "v") then
       push_cursor_21("bwd")
+    else
     end
+  else
   end
   return adjusted_pos
 end
-local function get_onscreen_lines(_108_)
-  local _arg_109_ = _108_
-  local reverse_3f = _arg_109_["reverse?"]
-  local skip_folds_3f = _arg_109_["skip-folds?"]
+local function get_onscreen_lines(_109_)
+  local _arg_110_ = _109_
+  local reverse_3f = _arg_110_["reverse?"]
+  local skip_folds_3f = _arg_110_["skip-folds?"]
   local lines = {}
   local wintop = vim.fn.line("w0")
   local winbot = vim.fn.line("w$")
   local lnum = vim.fn.line(".")
   while true do
-    local _110_
+    local _111_
     if reverse_3f then
-      _110_ = (lnum >= wintop)
+      _111_ = (lnum >= wintop)
     else
-      _110_ = (lnum <= winbot)
+      _111_ = (lnum <= winbot)
     end
-    if not _110_ then break end
+    if not _111_ then break end
     local fold_edge = get_fold_edge(lnum, reverse_3f)
     if (skip_folds_3f and fold_edge) then
-      local _112_
+      local _113_
       if reverse_3f then
-        _112_ = dec
+        _113_ = dec
       else
-        _112_ = inc
+        _113_ = inc
       end
-      lnum = _112_(fold_edge)
+      lnum = _113_(fold_edge)
     else
       lines[lnum] = vim.fn.getline(lnum)
-      local _114_
+      local _115_
       if reverse_3f then
-        _114_ = dec
+        _115_ = dec
       else
-        _114_ = inc
+        _115_ = inc
       end
-      lnum = _114_(lnum)
+      lnum = _115_(lnum)
     end
   end
   return lines
 end
-local function get_horizontal_bounds(_117_)
-  local _arg_118_ = _117_
-  local match_width = _arg_118_["match-width"]
+local function get_horizontal_bounds(_118_)
+  local _arg_119_ = _118_
+  local match_width = _arg_119_["match-width"]
   local textoff = (vim.fn.getwininfo(vim.fn.win_getid())[1].textoff or dec(leftmost_editable_wincol()))
   local offset_in_win = vim.fn.wincol()
   local offset_in_editable_win = (offset_in_win - textoff)
@@ -483,11 +542,11 @@ local function get_horizontal_bounds(_117_)
   local right_bound = (right_edge - dec(match_width))
   return {left_bound, right_bound}
 end
-local function onscreen_match_positions(pattern, reverse_3f, _119_)
-  local _arg_120_ = _119_
-  local ft_search_3f = _arg_120_["ft-search?"]
-  local limit = _arg_120_["limit"]
-  local to_eol_3f = _arg_120_["to-eol?"]
+local function onscreen_match_positions(pattern, reverse_3f, _120_)
+  local _arg_121_ = _120_
+  local to_eol_3f = _arg_121_["to-eol?"]
+  local ft_search_3f = _arg_121_["ft-search?"]
+  local limit = _arg_121_["limit"]
   local view = vim.fn.winsaveview()
   local cpo = vim.o.cpo
   local opts0
@@ -497,90 +556,96 @@ local function onscreen_match_positions(pattern, reverse_3f, _119_)
     opts0 = ""
   end
   local stopline
-  local function _122_()
+  local function _123_()
     if reverse_3f then
       return "w0"
     else
       return "w$"
     end
   end
-  stopline = vim.fn.line(_122_())
+  stopline = vim.fn.line(_123_())
   local cleanup
-  local function _123_()
+  local function _124_()
     vim.fn.winrestview(view)
     vim.o.cpo = cpo
     return nil
   end
-  cleanup = _123_
-  local _125_
+  cleanup = _124_
+  local _126_
   if ft_search_3f then
-    _125_ = 1
+    _126_ = 1
   else
-    _125_ = 2
+    _126_ = 2
   end
-  local _let_124_ = get_horizontal_bounds({["match-width"] = _125_})
-  local left_bound = _let_124_[1]
-  local right_bound = _let_124_[2]
+  local _let_125_ = get_horizontal_bounds({["match-width"] = _126_})
+  local left_bound = _let_125_[1]
+  local right_bound = _let_125_[2]
   local function skip_to_fold_edge_21()
-    local _127_
     local _128_
+    local _129_
     if reverse_3f then
-      _128_ = vim.fn.foldclosed
+      _129_ = vim.fn.foldclosed
     else
-      _128_ = vim.fn.foldclosedend
+      _129_ = vim.fn.foldclosedend
     end
-    _127_ = _128_(vim.fn.line("."))
-    if (_127_ == -1) then
+    _128_ = _129_(vim.fn.line("."))
+    if (_128_ == -1) then
       return "not-in-fold"
-    elseif (nil ~= _127_) then
-      local fold_edge = _127_
+    elseif (nil ~= _128_) then
+      local fold_edge = _128_
       vim.fn.cursor(fold_edge, 0)
-      local function _130_()
+      local function _131_()
         if reverse_3f then
           return 1
         else
           return vim.fn.col("$")
         end
       end
-      vim.fn.cursor(0, _130_())
+      vim.fn.cursor(0, _131_())
       return "moved-the-cursor"
+    else
+      return nil
     end
   end
   local function skip_to_next_in_window_pos_21()
-    local _local_132_ = get_cursor_pos()
-    local line = _local_132_[1]
-    local col = _local_132_[2]
-    local from_pos = _local_132_
-    local _133_
+    local _local_133_ = get_cursor_pos()
+    local line = _local_133_[1]
+    local col = _local_133_[2]
+    local from_pos = _local_133_
+    local _134_
     if (col < left_bound) then
       if reverse_3f then
         if (dec(line) >= stopline) then
-          _133_ = {dec(line), right_bound}
+          _134_ = {dec(line), right_bound}
         else
-        _133_ = nil
+          _134_ = nil
         end
       else
-        _133_ = {line, left_bound}
+        _134_ = {line, left_bound}
       end
     elseif (col > right_bound) then
       if reverse_3f then
-        _133_ = {line, right_bound}
+        _134_ = {line, right_bound}
       else
         if (inc(line) <= stopline) then
-          _133_ = {inc(line), left_bound}
+          _134_ = {inc(line), left_bound}
         else
-        _133_ = nil
+          _134_ = nil
         end
       end
     else
-    _133_ = nil
+      _134_ = nil
     end
-    if (nil ~= _133_) then
-      local to_pos = _133_
+    if (nil ~= _134_) then
+      local to_pos = _134_
       if (from_pos ~= to_pos) then
         vim.fn.cursor(to_pos)
         return "moved-the-cursor"
+      else
+        return nil
       end
+    else
+      return nil
     end
   end
   vim.o.cpo = cpo:gsub("c", "")
@@ -589,21 +654,22 @@ local function onscreen_match_positions(pattern, reverse_3f, _119_)
     if (limit and (match_count >= limit)) then
       return cleanup()
     else
-      local _141_
       local _142_
-      if match_at_curpos_3f then
-        _142_ = "c"
-      else
-        _142_ = ""
+      local function _143_()
+        if match_at_curpos_3f then
+          return "c"
+        else
+          return ""
+        end
       end
-      _141_ = vim.fn.searchpos(pattern, (opts0 .. _142_), stopline)
-      if ((type(_141_) == "table") and ((_141_)[1] == 0) and true) then
-        local _ = (_141_)[2]
+      _142_ = vim.fn.searchpos(pattern, (opts0 .. _143_()), stopline)
+      if ((_G.type(_142_) == "table") and ((_142_)[1] == 0) and true) then
+        local _ = (_142_)[2]
         return cleanup()
-      elseif ((type(_141_) == "table") and (nil ~= (_141_)[1]) and (nil ~= (_141_)[2])) then
-        local line = (_141_)[1]
-        local col = (_141_)[2]
-        local pos = _141_
+      elseif ((_G.type(_142_) == "table") and (nil ~= (_142_)[1]) and (nil ~= (_142_)[2])) then
+        local line = (_142_)[1]
+        local col = (_142_)[2]
+        local pos = _142_
         if ft_search_3f then
           match_count = (match_count + 1)
           return pos
@@ -619,13 +685,19 @@ local function onscreen_match_positions(pattern, reverse_3f, _119_)
               local _148_ = skip_to_next_in_window_pos_21()
               if (_148_ == "moved-the-cursor") then
                 return recur(true)
-              else
+              elseif true then
                 local _ = _148_
                 return cleanup()
+              else
+                return nil
               end
             end
+          else
+            return nil
           end
         end
+      else
+        return nil
       end
     end
   end
@@ -637,7 +709,7 @@ local function highlight_cursor(_3fpos)
   local col = _let_155_[2]
   local pos = _let_155_
   local ch_at_curpos = (char_at_pos(pos, {}) or " ")
-  return hl["set-extmark"](hl, dec(line), dec(col), {hl_mode = "combine", virt_text = {{ch_at_curpos, hl.group.cursor}}, virt_text_pos = "overlay"})
+  return hl["set-extmark"](hl, dec(line), dec(col), {virt_text = {{ch_at_curpos, hl.group.cursor}}, virt_text_pos = "overlay", hl_mode = "combine"})
 end
 local function handle_interrupted_change_op_21()
   echo("")
@@ -654,6 +726,8 @@ end
 local function doau_when_exists(event)
   if vim.fn.exists(("#User#" .. event)) then
     return vim.cmd(("doautocmd <nomodeline> User " .. event))
+  else
+    return nil
   end
 end
 local function enter(mode)
@@ -663,6 +737,8 @@ local function enter(mode)
     return doau_when_exists("LightspeedFtEnter")
   elseif (_158_ == "sx") then
     return doau_when_exists("LightspeedSxEnter")
+  else
+    return nil
   end
 end
 local function get_input(_3ftimeout)
@@ -676,6 +752,8 @@ local function get_input(_3ftimeout)
   local function _161_()
     if vim.wait(_3ftimeout, char_available_3f, 100) then
       return vim.fn.getchar(0)
+    else
+      return nil
     end
   end
   getchar_timeout = _161_
@@ -694,6 +772,8 @@ local function get_input(_3ftimeout)
     else
       return ch
     end
+  else
+    return nil
   end
 end
 local function set_dot_repeat(cmd, _3fcount)
@@ -702,47 +782,47 @@ local function set_dot_repeat(cmd, _3fcount)
   if (op == "c") then
     change = replace_keycodes("<c-r>.<esc>")
   else
-  change = nil
+    change = nil
   end
   local seq = (op .. (_3fcount or "") .. cmd .. (change or ""))
   pcall(vim.fn["repeat#setreg"], seq, vim.v.register)
   return pcall(vim.fn["repeat#set"], seq, -1)
 end
 local function get_plug_key(search_mode, reverse_3f, x_2ft_3f, repeat_invoc)
-  local _168_
-  do
+  local function _168_()
     local _167_ = repeat_invoc
     if (_167_ == "dot") then
-      _168_ = "dotrepeat_"
-    else
+      return "dotrepeat_"
+    elseif true then
       local _ = _167_
-      _168_ = ""
-    end
-  end
-  local _173_
-  do
-    local _172_ = {search_mode, not not reverse_3f, not not x_2ft_3f}
-    if ((type(_172_) == "table") and ((_172_)[1] == "ft") and ((_172_)[2] == false) and ((_172_)[3] == false)) then
-      _173_ = "f"
-    elseif ((type(_172_) == "table") and ((_172_)[1] == "ft") and ((_172_)[2] == true) and ((_172_)[3] == false)) then
-      _173_ = "F"
-    elseif ((type(_172_) == "table") and ((_172_)[1] == "ft") and ((_172_)[2] == false) and ((_172_)[3] == true)) then
-      _173_ = "t"
-    elseif ((type(_172_) == "table") and ((_172_)[1] == "ft") and ((_172_)[2] == true) and ((_172_)[3] == true)) then
-      _173_ = "T"
-    elseif ((type(_172_) == "table") and ((_172_)[1] == "sx") and ((_172_)[2] == false) and ((_172_)[3] == false)) then
-      _173_ = "s"
-    elseif ((type(_172_) == "table") and ((_172_)[1] == "sx") and ((_172_)[2] == true) and ((_172_)[3] == false)) then
-      _173_ = "S"
-    elseif ((type(_172_) == "table") and ((_172_)[1] == "sx") and ((_172_)[2] == false) and ((_172_)[3] == true)) then
-      _173_ = "x"
-    elseif ((type(_172_) == "table") and ((_172_)[1] == "sx") and ((_172_)[2] == true) and ((_172_)[3] == true)) then
-      _173_ = "X"
+      return ""
     else
-    _173_ = nil
+      return nil
     end
   end
-  return ("<Plug>Lightspeed_" .. _168_ .. _173_)
+  local function _171_()
+    local _170_ = {search_mode, not not reverse_3f, not not x_2ft_3f}
+    if ((_G.type(_170_) == "table") and ((_170_)[1] == "ft") and ((_170_)[2] == false) and ((_170_)[3] == false)) then
+      return "f"
+    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "ft") and ((_170_)[2] == true) and ((_170_)[3] == false)) then
+      return "F"
+    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "ft") and ((_170_)[2] == false) and ((_170_)[3] == true)) then
+      return "t"
+    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "ft") and ((_170_)[2] == true) and ((_170_)[3] == true)) then
+      return "T"
+    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "sx") and ((_170_)[2] == false) and ((_170_)[3] == false)) then
+      return "s"
+    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "sx") and ((_170_)[2] == true) and ((_170_)[3] == false)) then
+      return "S"
+    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "sx") and ((_170_)[2] == false) and ((_170_)[3] == true)) then
+      return "x"
+    elseif ((_G.type(_170_) == "table") and ((_170_)[1] == "sx") and ((_170_)[2] == true) and ((_170_)[3] == true)) then
+      return "X"
+    else
+      return nil
+    end
+  end
+  return ("<Plug>Lightspeed_" .. _168_() .. _171_())
 end
 local function get_repeat_action(_in, search_mode, x_2ft_3f, instant_repeat_3f, from_reverse_cold_repeat_3f, _3ftarget_char)
   local mode
@@ -754,27 +834,29 @@ local function get_repeat_action(_in, search_mode, x_2ft_3f, instant_repeat_3f, 
   local in_mapped_to = maparg_expr(_in, mode)
   local repeat_plug_key = ("<Plug>Lightspeed_;_" .. search_mode)
   local revert_plug_key = ("<Plug>Lightspeed_,_" .. search_mode)
-  local _184_
+  local _174_
   if from_reverse_cold_repeat_3f then
-    _184_ = revert_plug_key
+    _174_ = revert_plug_key
   else
-    _184_ = repeat_plug_key
+    _174_ = repeat_plug_key
   end
-  if ((_in == _3cbackspace_3e) or ((search_mode == "ft") and opts.repeat_ft_with_target_char and (_in == _3ftarget_char)) or ((in_mapped_to == get_plug_key(search_mode, false, x_2ft_3f)) or (in_mapped_to == _184_))) then
+  if ((_in == _3cbackspace_3e) or ((search_mode == "ft") and opts.repeat_ft_with_target_char and (_in == _3ftarget_char)) or ((in_mapped_to == get_plug_key(search_mode, false, x_2ft_3f)) or (in_mapped_to == _174_))) then
     return "repeat"
   else
-    local _186_
+    local _176_
     if from_reverse_cold_repeat_3f then
-      _186_ = repeat_plug_key
+      _176_ = repeat_plug_key
     else
-      _186_ = revert_plug_key
+      _176_ = revert_plug_key
     end
-    if (instant_repeat_3f and ((_in == "\9") or ((in_mapped_to == get_plug_key(search_mode, true, x_2ft_3f)) or (in_mapped_to == _186_)))) then
+    if (instant_repeat_3f and ((_in == "\9") or ((in_mapped_to == get_plug_key(search_mode, true, x_2ft_3f)) or (in_mapped_to == _176_)))) then
       return "revert"
+    else
+      return nil
     end
   end
 end
-local ft = {state = {cold = {["in"] = nil, ["reverse?"] = nil, ["t-mode?"] = nil}, dot = {["in"] = nil}}}
+local ft = {state = {dot = {["in"] = nil}, cold = {["in"] = nil, ["reverse?"] = nil, ["t-mode?"] = nil}}}
 ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
   local mode = api.nvim_get_mode().mode
   local op_mode_3f = mode:match("o")
@@ -784,29 +866,30 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
   if instant_repeat_3f then
     instant_state = repeat_invoc
   else
-  instant_state = nil
+    instant_state = nil
   end
   local reverted_instant_repeat_3f
   do
-    local t_190_ = instant_state
-    if (nil ~= t_190_) then
-      t_190_ = (t_190_)["reverted?"]
+    local t_180_ = instant_state
+    if (nil ~= t_180_) then
+      t_180_ = (t_180_)["reverted?"]
+    else
     end
-    reverted_instant_repeat_3f = t_190_
+    reverted_instant_repeat_3f = t_180_
   end
   local cold_repeat_3f = (repeat_invoc == "cold")
   local dot_repeat_3f = (repeat_invoc == "dot")
   local invoked_as_reverse_3f = reverse_3f
   local reverse_3f0
   if cold_repeat_3f then
-    local function _192_(_241)
+    local function _182_(_241)
       if invoked_as_reverse_3f then
         return not _241
       else
         return _241
       end
     end
-    reverse_3f0 = _192_(self.state.cold["reverse?"])
+    reverse_3f0 = _182_(self.state.cold["reverse?"])
   else
     reverse_3f0 = reverse_3f
   end
@@ -829,28 +912,28 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
     count0 = count
   end
   local function get_num_of_matches_to_be_highlighted()
-    local _198_ = opts.limit_ft_matches
-    local function _199_()
-      local group_limit = _198_
+    local _188_ = opts.limit_ft_matches
+    local function _189_()
+      local group_limit = _188_
       return (group_limit > 0)
     end
-    if ((nil ~= _198_) and _199_()) then
-      local group_limit = _198_
+    if ((nil ~= _188_) and _189_()) then
+      local group_limit = _188_
       local matches_left_behind
-      local function _201_()
-        local _200_ = instant_state
-        if _200_ then
-          local _202_ = (_200_).stack
-          if _202_ then
-            return #_202_
+      local function _191_()
+        local _190_ = instant_state
+        if (nil ~= _190_) then
+          local _192_ = (_190_).stack
+          if (nil ~= _192_) then
+            return #_192_
           else
-            return _202_
+            return _192_
           end
         else
-          return _200_
+          return _190_
         end
       end
-      matches_left_behind = (_201_() or 0)
+      matches_left_behind = (_191_() or 0)
       local eaten_up = (matches_left_behind % group_limit)
       local remaining = (group_limit - eaten_up)
       if (remaining == 0) then
@@ -858,29 +941,33 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       else
         return remaining
       end
-    else
-      local _ = _198_
+    elseif true then
+      local _ = _188_
       return 0
+    else
+      return nil
     end
   end
   if not instant_repeat_3f then
     enter("ft")
+  else
   end
   if not repeat_invoc then
     echo("")
     highlight_cursor()
     vim.cmd("redraw")
-  end
-  local _209_
-  if instant_repeat_3f then
-    _209_ = instant_state["in"]
-  elseif dot_repeat_3f then
-    _209_ = self.state.dot["in"]
-  elseif cold_repeat_3f then
-    _209_ = self.state.cold["in"]
   else
-    local _210_
-    local function _211_()
+  end
+  local _199_
+  if instant_repeat_3f then
+    _199_ = instant_state["in"]
+  elseif dot_repeat_3f then
+    _199_ = self.state.dot["in"]
+  elseif cold_repeat_3f then
+    _199_ = self.state.cold["in"]
+  else
+    local _200_
+    local function _201_()
       local res_2_auto
       do
         res_2_auto = get_input()
@@ -888,9 +975,10 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       hl:cleanup()
       return res_2_auto
     end
-    local function _212_()
+    local function _202_()
       if change_operation_3f() then
         handle_interrupted_change_op_21()
+      else
       end
       do
       end
@@ -898,11 +986,12 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       doau_when_exists("LightspeedLeave")
       return nil
     end
-    _210_ = (_211_() or _212_())
-    if (_210_ == _3cbackspace_3e) then
-      local function _214_()
+    _200_ = (_201_() or _202_())
+    if (_200_ == _3cbackspace_3e) then
+      local function _204_()
         if change_operation_3f() then
           handle_interrupted_change_op_21()
+        else
         end
         do
           echo_no_prev_search()
@@ -911,65 +1000,70 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
         doau_when_exists("LightspeedLeave")
         return nil
       end
-      _209_ = (self.state.cold["in"] or _214_())
-    elseif (nil ~= _210_) then
-      local _in = _210_
-      _209_ = _in
+      _199_ = (self.state.cold["in"] or _204_())
+    elseif (nil ~= _200_) then
+      local _in = _200_
+      _199_ = _in
     else
-    _209_ = nil
+      _199_ = nil
     end
   end
-  if (nil ~= _209_) then
-    local in1 = _209_
+  if (nil ~= _199_) then
+    local in1 = _199_
     local to_eol_3f = (in1 == "\13")
     if not repeat_invoc then
       self.state.cold = {["in"] = in1, ["reverse?"] = reverse_3f0, ["t-mode?"] = t_mode_3f0}
+    else
     end
     local jump_pos = nil
     local match_count = 0
     do
       local next_pos
-      local function _219_()
+      local function _209_()
         if reverse_3f0 then
           return "nWb"
         else
           return "nW"
         end
       end
-      next_pos = vim.fn.searchpos("\\_.", _219_())
+      next_pos = vim.fn.searchpos("\\_.", _209_())
       local pattern
       if to_eol_3f then
         pattern = "\\n"
       else
-        local _220_
-        if opts.ignore_case then
-          _220_ = "\\c"
-        else
-          _220_ = "\\C"
+        local function _210_()
+          if opts.ignore_case then
+            return "\\c"
+          else
+            return "\\C"
+          end
         end
-        pattern = ("\\V" .. _220_ .. in1:gsub("\\", "\\\\"))
+        pattern = ("\\V" .. _210_() .. in1:gsub("\\", "\\\\"))
       end
       local limit = (count0 + get_num_of_matches_to_be_highlighted())
-      for _223_ in onscreen_match_positions(pattern, reverse_3f0, {["ft-search?"] = true, limit = limit}) do
-        local _each_224_ = _223_
-        local line = _each_224_[1]
-        local col = _each_224_[2]
-        local pos = _each_224_
+      for _212_ in onscreen_match_positions(pattern, reverse_3f0, {["ft-search?"] = true, limit = limit}) do
+        local _each_213_ = _212_
+        local line = _each_213_[1]
+        local col = _each_213_[2]
+        local pos = _each_213_
         if not ((match_count == 0) and cold_repeat_3f and t_mode_3f0 and same_pos_3f(pos, next_pos)) then
           if (match_count <= dec(count0)) then
             jump_pos = pos
           else
             if not op_mode_3f then
               hl["add-hl"](hl, hl.group["one-char-match"], dec(line), dec(col), col)
+            else
             end
           end
           match_count = (match_count + 1)
+        else
         end
       end
     end
     if (not reverted_instant_repeat_3f and ((match_count == 0) or ((match_count == 1) and instant_repeat_3f and t_mode_3f0))) then
       if change_operation_3f() then
         handle_interrupted_change_op_21()
+      else
       end
       do
         echo_not_found(in1)
@@ -979,28 +1073,34 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       return nil
     else
       if not reverted_instant_repeat_3f then
-        local function _229_()
+        local function _218_()
           if t_mode_3f0 then
-            local function _230_()
+            local function _219_()
               if reverse_3f0 then
                 return "fwd"
               else
                 return "bwd"
               end
             end
-            push_cursor_21(_230_())
+            push_cursor_21(_219_())
             if (to_eol_3f and not reverse_3f0 and mode:match("n")) then
               return push_cursor_21("fwd")
+            else
+              return nil
             end
+          else
+            return nil
           end
         end
-        jump_to_21_2a(jump_pos, {["add-to-jumplist?"] = not instant_repeat_3f, ["inclusive-motion?"] = true, ["reverse?"] = reverse_3f0, adjust = _229_, mode = mode})
+        jump_to_21_2a(jump_pos, {mode = mode, ["reverse?"] = reverse_3f0, ["inclusive-motion?"] = true, ["add-to-jumplist?"] = not instant_repeat_3f, adjust = _218_})
+      else
       end
       if op_mode_3f then
         do
           if dot_repeatable_op_3f then
             self.state.dot = {["in"] = in1}
             set_dot_repeat(replace_keycodes(get_plug_key("ft", reverse_3f0, t_mode_3f0, "dot")), count0)
+          else
           end
         end
         doau_when_exists("LightspeedFtLeave")
@@ -1009,8 +1109,8 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
       else
         highlight_cursor()
         vim.cmd("redraw")
-        local _235_
-        local function _236_()
+        local _224_
+        local function _225_()
           local res_2_auto
           do
             res_2_auto = get_input(opts.exit_after_idle_msecs.unlabeled)
@@ -1018,75 +1118,84 @@ ft.go = function(self, reverse_3f, t_mode_3f, repeat_invoc)
           hl:cleanup()
           return res_2_auto
         end
-        local function _237_()
+        local function _226_()
           do
           end
           doau_when_exists("LightspeedFtLeave")
           doau_when_exists("LightspeedLeave")
           return nil
         end
-        _235_ = (_236_() or _237_())
-        if (nil ~= _235_) then
-          local in2 = _235_
+        _224_ = (_225_() or _226_())
+        if (nil ~= _224_) then
+          local in2 = _224_
           local stack
-          local function _239_()
-            local t_238_ = instant_state
-            if (nil ~= t_238_) then
-              t_238_ = (t_238_).stack
+          local function _228_()
+            local t_227_ = instant_state
+            if (nil ~= t_227_) then
+              t_227_ = (t_227_).stack
+            else
             end
-            return t_238_
+            return t_227_
           end
-          stack = (_239_() or {})
+          stack = (_228_() or {})
           local from_reverse_cold_repeat_3f
           if instant_repeat_3f then
             from_reverse_cold_repeat_3f = instant_state["from-reverse-cold-repeat?"]
           else
             from_reverse_cold_repeat_3f = (cold_repeat_3f and invoked_as_reverse_3f)
           end
-          local _242_ = get_repeat_action(in2, "ft", t_mode_3f0, instant_repeat_3f, from_reverse_cold_repeat_3f, in1)
-          if (_242_ == "repeat") then
+          local _231_ = get_repeat_action(in2, "ft", t_mode_3f0, instant_repeat_3f, from_reverse_cold_repeat_3f, in1)
+          if (_231_ == "repeat") then
             table.insert(stack, get_cursor_pos())
-            return ft:go(reverse_3f0, t_mode_3f0, {["from-reverse-cold-repeat?"] = from_reverse_cold_repeat_3f, ["in"] = in1, ["reverted?"] = false, stack = stack})
-          elseif (_242_ == "revert") then
+            return ft:go(reverse_3f0, t_mode_3f0, {["in"] = in1, stack = stack, ["reverted?"] = false, ["from-reverse-cold-repeat?"] = from_reverse_cold_repeat_3f})
+          elseif (_231_ == "revert") then
             do
-              local _243_ = table.remove(stack)
-              if _243_ then
-                vim.fn.cursor(_243_)
+              local _232_ = table.remove(stack)
+              if (nil ~= _232_) then
+                vim.fn.cursor(_232_)
               else
               end
             end
-            return ft:go(reverse_3f0, t_mode_3f0, {["from-reverse-cold-repeat?"] = from_reverse_cold_repeat_3f, ["in"] = in1, ["reverted?"] = true, stack = stack})
-          else
-            local _ = _242_
+            return ft:go(reverse_3f0, t_mode_3f0, {["in"] = in1, stack = stack, ["reverted?"] = true, ["from-reverse-cold-repeat?"] = from_reverse_cold_repeat_3f})
+          elseif true then
+            local _ = _231_
             do
               vim.fn.feedkeys(in2, "i")
             end
             doau_when_exists("LightspeedFtLeave")
             doau_when_exists("LightspeedLeave")
             return nil
+          else
+            return nil
           end
+        else
+          return nil
         end
       end
     end
+  else
+    return nil
   end
 end
 do
   local deprec_msg = {{"ligthspeed.nvim", "Question"}, {": You're trying to access deprecated fields in the lightspeed.ft table.\n"}, {"There are dedicated <Plug> keys available for native-like "}, {";", "Visual"}, {" and "}, {",", "Visual"}, {" functionality now.\n"}, {"See "}, {":h lightspeed-custom-mappings", "Visual"}, {"."}}
-  local function _250_(t, k)
+  local function _239_(t, k)
     if ((k == "instant-repeat?") or (k == "prev-t-like?")) then
       return api.nvim_echo(deprec_msg, true, {})
+    else
+      return nil
     end
   end
-  setmetatable(ft, {__index = _250_})
+  setmetatable(ft, {__index = _239_})
 end
 local function highlight_unique_chars(reverse_3f)
   local unique_chars = {}
-  local _let_252_ = get_horizontal_bounds({["match-width"] = 2})
-  local left_bound = _let_252_[1]
-  local right_bound = _let_252_[2]
-  local _let_253_ = get_cursor_pos()
-  local curline = _let_253_[1]
-  local curcol = _let_253_[2]
+  local _let_241_ = get_horizontal_bounds({["match-width"] = 2})
+  local left_bound = _let_241_[1]
+  local right_bound = _let_241_[2]
+  local _let_242_ = get_cursor_pos()
+  local curline = _let_242_[1]
+  local curcol = _let_242_[2]
   for lnum, line in pairs(get_onscreen_lines({["reverse?"] = reverse_3f, ["skip-folds?"] = true})) do
     local on_curline_3f = (lnum == curline)
     local startcol
@@ -1110,27 +1219,31 @@ local function highlight_unique_chars(reverse_3f)
         else
           ch0 = ch
         end
-        local _258_
+        local _247_
         do
-          local _257_ = unique_chars[ch0]
-          if (nil ~= _257_) then
-            local pos_already_there = _257_
-            _258_ = false
+          local _246_ = unique_chars[ch0]
+          if (nil ~= _246_) then
+            local pos_already_there = _246_
+            _247_ = false
+          elseif true then
+            local _ = _246_
+            _247_ = {lnum, col}
           else
-            local _ = _257_
-            _258_ = {lnum, col}
+            _247_ = nil
           end
         end
-        unique_chars[ch0] = _258_
+        unique_chars[ch0] = _247_
+      else
       end
     end
   end
   for ch, pos in pairs(unique_chars) do
-    local _263_ = pos
-    if ((type(_263_) == "table") and (nil ~= (_263_)[1]) and (nil ~= (_263_)[2])) then
-      local lnum = (_263_)[1]
-      local col = (_263_)[2]
+    local _252_ = pos
+    if ((_G.type(_252_) == "table") and (nil ~= (_252_)[1]) and (nil ~= (_252_)[2])) then
+      local lnum = (_252_)[1]
+      local col = (_252_)[2]
       hl["add-hl"](hl, hl.group["unique-ch"], dec(lnum), dec(col), col)
+    else
     end
   end
   return nil
@@ -1144,49 +1257,50 @@ local function get_targets(input, reverse_3f)
   if to_eol_3f then
     pattern = "\\n"
   else
-    local _265_
-    if opts.ignore_case then
-      _265_ = "\\c"
-    else
-      _265_ = "\\C"
+    local function _254_()
+      if opts.ignore_case then
+        return "\\c"
+      else
+        return "\\C"
+      end
     end
-    pattern = ("\\V" .. _265_ .. input:gsub("\\", "\\\\") .. "\\_.")
+    pattern = ("\\V" .. _254_() .. input:gsub("\\", "\\\\") .. "\\_.")
   end
-  for _268_ in onscreen_match_positions(pattern, reverse_3f, {["to-eol?"] = to_eol_3f}) do
-    local _each_269_ = _268_
-    local line = _each_269_[1]
-    local col = _each_269_[2]
-    local pos = _each_269_
+  for _256_ in onscreen_match_positions(pattern, reverse_3f, {["to-eol?"] = to_eol_3f}) do
+    local _each_257_ = _256_
+    local line = _each_257_[1]
+    local col = _each_257_[2]
+    local pos = _each_257_
     if to_eol_3f then
-      table.insert(targets, {pair = {"\n", ""}, pos = pos})
+      table.insert(targets, {pos = pos, pair = {"\n", ""}})
     else
       local ch1 = char_at_pos(pos, {})
       local ch2 = (char_at_pos(pos, {["char-offset"] = 1}) or "\13")
       local to_pre_eol_3f = (ch2 == "\13")
       local overlaps_prev_match_3f
-      local _270_
+      local _258_
       if reverse_3f then
-        _270_ = dec
+        _258_ = dec
       else
-        _270_ = inc
+        _258_ = inc
       end
-      overlaps_prev_match_3f = ((line == prev_match.line) and (col == _270_(prev_match.col)))
+      overlaps_prev_match_3f = ((line == prev_match.line) and (col == _258_(prev_match.col)))
       local same_char_triplet_3f = (overlaps_prev_match_3f and (ch2 == prev_match.ch2))
       local overlaps_prev_target_3f = (overlaps_prev_match_3f and added_prev_match_3f)
-      prev_match = {ch2 = ch2, col = col, line = line}
+      prev_match = {line = line, col = col, ch2 = ch2}
       if (same_char_triplet_3f and (added_prev_match_3f or opts.match_only_the_start_of_same_char_seqs)) then
         added_prev_match_3f = false
       else
-        local target = {pair = {ch1, ch2}, pos = pos}
+        local target = {pos = pos, pair = {ch1, ch2}}
         local prev_target = last(targets)
         local match_width = 2
         local touches_prev_target_3f
         do
-          local _272_ = prev_target
-          if ((type(_272_) == "table") and ((type((_272_).pos) == "table") and (nil ~= ((_272_).pos)[1]) and (nil ~= ((_272_).pos)[2]))) then
-            local prev_line = ((_272_).pos)[1]
-            local prev_col = ((_272_).pos)[2]
-            local function _274_()
+          local _260_ = prev_target
+          if ((_G.type(_260_) == "table") and ((_G.type((_260_).pos) == "table") and (nil ~= ((_260_).pos)[1]) and (nil ~= ((_260_).pos)[2]))) then
+            local prev_line = ((_260_).pos)[1]
+            local prev_col = ((_260_).pos)[2]
+            local function _262_()
               local col_delta
               if reverse_3f then
                 col_delta = (prev_col - col)
@@ -1195,31 +1309,34 @@ local function get_targets(input, reverse_3f)
               end
               return (col_delta <= match_width)
             end
-            touches_prev_target_3f = ((line == prev_line) and _274_())
+            touches_prev_target_3f = ((line == prev_line) and _262_())
           else
-          touches_prev_target_3f = nil
+            touches_prev_target_3f = nil
           end
         end
         if to_pre_eol_3f then
           target["squeezed?"] = true
+        else
         end
         if touches_prev_target_3f then
-          local _277_
+          local _265_
           if reverse_3f then
-            _277_ = target
+            _265_ = target
           else
-            _277_ = prev_target
+            _265_ = prev_target
           end
-          _277_["squeezed?"] = true
+          _265_["squeezed?"] = true
+        else
         end
         if overlaps_prev_target_3f then
-          local _280_
+          local _268_
           if reverse_3f then
-            _280_ = prev_target
+            _268_ = prev_target
           else
-            _280_ = target
+            _268_ = target
           end
-          _280_["overlapped?"] = true
+          _268_["overlapped?"] = true
+        else
         end
         table.insert(targets, target)
         added_prev_match_3f = true
@@ -1228,22 +1345,25 @@ local function get_targets(input, reverse_3f)
   end
   if next(targets) then
     return targets
+  else
+    return nil
   end
 end
 local function populate_sublists(targets)
   targets["sublists"] = {}
   if opts.ignore_case then
-    local function _286_(self, k)
+    local function _274_(self, k)
       return rawget(self, k:lower())
     end
-    setmetatable(targets.sublists, {__index = _286_})
+    setmetatable(targets.sublists, {__index = _274_})
+  else
   end
-  for _, _288_ in ipairs(targets) do
-    local _each_289_ = _288_
-    local target = _each_289_
-    local _each_290_ = _each_289_["pair"]
-    local _0 = _each_290_[1]
-    local ch2 = _each_290_[2]
+  for _, _276_ in ipairs(targets) do
+    local _each_277_ = _276_
+    local _each_278_ = _each_277_["pair"]
+    local _0 = _each_278_[1]
+    local ch2 = _each_278_[2]
+    local target = _each_277_
     local k
     if opts.ignore_case then
       k = ch2:lower()
@@ -1252,6 +1372,7 @@ local function populate_sublists(targets)
     end
     if not targets.sublists[k] then
       targets["sublists"][k] = {}
+    else
     end
     table.insert(targets.sublists[k], target)
   end
@@ -1260,26 +1381,31 @@ end
 local function get_labels(sublist, to_eol_3f)
   if to_eol_3f then
     sublist["autojump?"] = false
+  else
   end
   if (not opts.safe_labels or empty_3f(opts.safe_labels)) then
     if (sublist["autojump?"] == nil) then
       sublist["autojump?"] = false
+    else
     end
     return opts.labels
   elseif (not opts.labels or empty_3f(opts.labels)) then
     if (sublist["autojump?"] == nil) then
       sublist["autojump?"] = true
+    else
     end
     return opts.safe_labels
   else
-    local _296_ = sublist["autojump?"]
-    if (_296_ == true) then
+    local _284_ = sublist["autojump?"]
+    if (_284_ == true) then
       return opts.safe_labels
-    elseif (_296_ == false) then
+    elseif (_284_ == false) then
       return opts.labels
-    elseif (_296_ == nil) then
+    elseif (_284_ == nil) then
       sublist["autojump?"] = (not operator_pending_mode_3f() and (dec(#sublist) <= #opts.safe_labels))
       return get_labels(sublist)
+    else
+      return nil
     end
   end
 end
@@ -1288,63 +1414,66 @@ local function set_labels(targets, to_eol_3f)
     if (#sublist > 1) then
       local labels = get_labels(sublist, to_eol_3f)
       for i, target in ipairs(sublist) do
-        local _299_
+        local _287_
         if not (sublist["autojump?"] and (i == 1)) then
-          local _300_
-          local _302_
-          if sublist["autojump?"] then
-            _302_ = dec(i)
-          else
-            _302_ = i
+          local _288_
+          local function _290_()
+            if sublist["autojump?"] then
+              return dec(i)
+            else
+              return i
+            end
           end
-          _300_ = (_302_ % #labels)
-          if (_300_ == 0) then
-            _299_ = last(labels)
-          elseif (nil ~= _300_) then
-            local n = _300_
-            _299_ = labels[n]
+          _288_ = (_290_() % #labels)
+          if (_288_ == 0) then
+            _287_ = last(labels)
+          elseif (nil ~= _288_) then
+            local n = _288_
+            _287_ = labels[n]
           else
-          _299_ = nil
+            _287_ = nil
           end
         else
-        _299_ = nil
+          _287_ = nil
         end
-        target["label"] = _299_
+        target["label"] = _287_
       end
+    else
     end
   end
   return nil
 end
-local function set_label_states_for_sublist(sublist, _309_)
-  local _arg_310_ = _309_
-  local group_offset = _arg_310_["group-offset"]
+local function set_label_states_for_sublist(sublist, _296_)
+  local _arg_297_ = _296_
+  local group_offset = _arg_297_["group-offset"]
   local labels = get_labels(sublist)
   local _7clabels_7c = #labels
   local offset = (group_offset * _7clabels_7c)
   local primary_start
-  local _311_
-  if sublist["autojump?"] then
-    _311_ = 2
-  else
-    _311_ = 1
+  local function _298_()
+    if sublist["autojump?"] then
+      return 2
+    else
+      return 1
+    end
   end
-  primary_start = (offset + _311_)
+  primary_start = (offset + _298_())
   local primary_end = (primary_start + dec(_7clabels_7c))
   local secondary_end = (primary_end + _7clabels_7c)
   for i, target in ipairs(sublist) do
-    local _313_
+    local _299_
     if target.label then
       if ((i < primary_start) or (i > secondary_end)) then
-        _313_ = "inactive"
+        _299_ = "inactive"
       elseif (i <= primary_end) then
-        _313_ = "active-primary"
+        _299_ = "active-primary"
       else
-        _313_ = "active-secondary"
+        _299_ = "active-secondary"
       end
     else
-    _313_ = nil
+      _299_ = nil
     end
-    target["label-state"] = _313_
+    target["label-state"] = _299_
   end
   return nil
 end
@@ -1358,57 +1487,60 @@ local function set_shortcuts_and_populate_shortcuts_map(targets)
   targets["shortcuts"] = {}
   local potential_2nd_inputs
   do
-    local tbl_9_auto = {}
+    local tbl_12_auto = {}
     for ch2, _ in pairs(targets.sublists) do
-      local _316_, _317_ = ch2, true
-      if ((nil ~= _316_) and (nil ~= _317_)) then
-        local k_10_auto = _316_
-        local v_11_auto = _317_
-        tbl_9_auto[k_10_auto] = v_11_auto
+      local _302_, _303_ = ch2, true
+      if ((nil ~= _302_) and (nil ~= _303_)) then
+        local k_13_auto = _302_
+        local v_14_auto = _303_
+        tbl_12_auto[k_13_auto] = v_14_auto
+      else
       end
     end
-    potential_2nd_inputs = tbl_9_auto
+    potential_2nd_inputs = tbl_12_auto
   end
   local labels_used_up_as_shortcut = {}
-  for _, _319_ in ipairs(targets) do
-    local _each_320_ = _319_
-    local target = _each_320_
-    local label = _each_320_["label"]
-    local label_state = _each_320_["label-state"]
+  for _, _305_ in ipairs(targets) do
+    local _each_306_ = _305_
+    local label = _each_306_["label"]
+    local label_state = _each_306_["label-state"]
+    local target = _each_306_
     if (label_state == "active-primary") then
       if not ((potential_2nd_inputs)[label] or labels_used_up_as_shortcut[label]) then
         target["shortcut?"] = true
         targets.shortcuts[label] = target
         labels_used_up_as_shortcut[label] = true
+      else
       end
+    else
     end
   end
   return nil
 end
-local function set_beacon(_323_, _repeat)
-  local _arg_324_ = _323_
-  local target = _arg_324_
-  local label = _arg_324_["label"]
-  local label_state = _arg_324_["label-state"]
-  local overlapped_3f = _arg_324_["overlapped?"]
-  local _arg_325_ = _arg_324_["pair"]
-  local ch1 = _arg_325_[1]
-  local ch2 = _arg_325_[2]
-  local _arg_326_ = _arg_324_["pos"]
-  local _ = _arg_326_[1]
-  local col = _arg_326_[2]
-  local shortcut_3f = _arg_324_["shortcut?"]
-  local squeezed_3f = _arg_324_["squeezed?"]
+local function set_beacon(_309_, _repeat)
+  local _arg_310_ = _309_
+  local _arg_311_ = _arg_310_["pos"]
+  local _ = _arg_311_[1]
+  local col = _arg_311_[2]
+  local _arg_312_ = _arg_310_["pair"]
+  local ch1 = _arg_312_[1]
+  local ch2 = _arg_312_[2]
+  local label = _arg_310_["label"]
+  local label_state = _arg_310_["label-state"]
+  local squeezed_3f = _arg_310_["squeezed?"]
+  local overlapped_3f = _arg_310_["overlapped?"]
+  local shortcut_3f = _arg_310_["shortcut?"]
+  local target = _arg_310_
   local to_eol_3f = ((ch1 == "\n") and (ch2 == ""))
-  local _let_327_ = get_horizontal_bounds({["match-width"] = 1})
-  local left_bound = _let_327_[1]
-  local right_bound = _let_327_[2]
-  local function _329_(_241)
+  local _let_313_ = get_horizontal_bounds({["match-width"] = 1})
+  local left_bound = _let_313_[1]
+  local right_bound = _let_313_[2]
+  local function _315_(_241)
     return (opts.substitute_chars[_241] or _241)
   end
-  local _let_328_ = map(_329_, {ch1, ch2})
-  local ch10 = _let_328_[1]
-  local ch20 = _let_328_[2]
+  local _let_314_ = map(_315_, {ch1, ch2})
+  local ch10 = _let_314_[1]
+  local ch20 = _let_314_[2]
   local masked_char_24 = {ch20, hl.group["masked-ch"]}
   local label_24 = {label, hl.group.label}
   local shortcut_24 = {label, hl.group.shortcut}
@@ -1417,8 +1549,8 @@ local function set_beacon(_323_, _repeat)
   local overlapped_shortcut_24 = {label, hl.group["shortcut-overlapped"]}
   local overlapped_distant_label_24 = {label, hl.group["label-distant-overlapped"]}
   do
-    local _330_ = label_state
-    if (_330_ == nil) then
+    local _316_ = label_state
+    if (_316_ == nil) then
       if not (_repeat or to_eol_3f) then
         if overlapped_3f then
           target.beacon = {1, {{ch20, hl.group["unlabeled-match"]}}}
@@ -1426,9 +1558,9 @@ local function set_beacon(_323_, _repeat)
           target.beacon = {0, {{(ch10 .. ch20), hl.group["unlabeled-match"]}}}
         end
       else
-      target.beacon = nil
+        target.beacon = nil
       end
-    elseif (_330_ == "active-primary") then
+    elseif (_316_ == "active-primary") then
       if to_eol_3f then
         if (vim.wo.wrap or ((col <= right_bound) and (col >= left_bound))) then
           target.beacon = {0, {shortcut_24}}
@@ -1437,16 +1569,16 @@ local function set_beacon(_323_, _repeat)
         elseif (col < left_bound) then
           target.beacon = {0, {{"<", hl.group["one-char-match"]}, shortcut_24}, "left-off"}
         else
-        target.beacon = nil
+          target.beacon = nil
         end
       elseif _repeat then
-        local _334_
+        local _320_
         if squeezed_3f then
-          _334_ = 1
+          _320_ = 1
         else
-          _334_ = 2
+          _320_ = 2
         end
-        target.beacon = {_334_, {shortcut_24}}
+        target.beacon = {_320_, {shortcut_24}}
       elseif shortcut_3f then
         if overlapped_3f then
           target.beacon = {1, {overlapped_shortcut_24}}
@@ -1464,7 +1596,7 @@ local function set_beacon(_323_, _repeat)
       else
         target.beacon = {2, {label_24}}
       end
-    elseif (_330_ == "active-secondary") then
+    elseif (_316_ == "active-secondary") then
       if to_eol_3f then
         if (vim.wo.wrap or ((col <= right_bound) and (col >= left_bound))) then
           target.beacon = {0, {distant_label_24}}
@@ -1473,16 +1605,16 @@ local function set_beacon(_323_, _repeat)
         elseif (col < left_bound) then
           target.beacon = {0, {{"<", hl.group["unlabeled-match"]}, distant_label_24}, "left-off"}
         else
-        target.beacon = nil
+          target.beacon = nil
         end
       elseif _repeat then
-        local _340_
+        local _326_
         if squeezed_3f then
-          _340_ = 1
+          _326_ = 1
         else
-          _340_ = 2
+          _326_ = 2
         end
-        target.beacon = {_340_, {distant_label_24}}
+        target.beacon = {_326_, {distant_label_24}}
       elseif overlapped_3f then
         target.beacon = {1, {overlapped_distant_label_24}}
       elseif squeezed_3f then
@@ -1490,17 +1622,17 @@ local function set_beacon(_323_, _repeat)
       else
         target.beacon = {2, {distant_label_24}}
       end
-    elseif (_330_ == "inactive") then
+    elseif (_316_ == "inactive") then
       target.beacon = nil
     else
-    target.beacon = nil
+      target.beacon = nil
     end
   end
   return nil
 end
-local function set_beacons(target_list, _344_)
-  local _arg_345_ = _344_
-  local _repeat = _arg_345_["repeat"]
+local function set_beacons(target_list, _330_)
+  local _arg_331_ = _330_
+  local _repeat = _arg_331_["repeat"]
   for _, target in ipairs(target_list) do
     set_beacon(target, _repeat)
   end
@@ -1508,51 +1640,57 @@ local function set_beacons(target_list, _344_)
 end
 local function light_up_beacons(target_list, _3fstart_idx)
   for i = (_3fstart_idx or 1), #target_list do
-    local _let_346_ = target_list[i]
-    local beacon = _let_346_["beacon"]
-    local _let_347_ = _let_346_["pos"]
-    local line = _let_347_[1]
-    local col = _let_347_[2]
-    local _348_ = beacon
-    if ((type(_348_) == "table") and (nil ~= (_348_)[1]) and (nil ~= (_348_)[2]) and true) then
-      local offset = (_348_)[1]
-      local chunks = (_348_)[2]
-      local _3fleft_off_3f = (_348_)[3]
-      local _349_
+    local _let_332_ = target_list[i]
+    local _let_333_ = _let_332_["pos"]
+    local line = _let_333_[1]
+    local col = _let_333_[2]
+    local beacon = _let_332_["beacon"]
+    local _334_ = beacon
+    if ((_G.type(_334_) == "table") and (nil ~= (_334_)[1]) and (nil ~= (_334_)[2]) and true) then
+      local offset = (_334_)[1]
+      local chunks = (_334_)[2]
+      local _3fleft_off_3f = (_334_)[3]
+      local _335_
       if _3fleft_off_3f then
-        _349_ = 0
+        _335_ = 0
       else
-      _349_ = nil
+        _335_ = nil
       end
-      hl["set-extmark"](hl, dec(line), dec((col + offset)), {virt_text = chunks, virt_text_pos = "overlay", virt_text_win_col = _349_})
+      hl["set-extmark"](hl, dec(line), dec((col + offset)), {virt_text = chunks, virt_text_pos = "overlay", virt_text_win_col = _335_})
+    else
     end
   end
   return nil
 end
 local function get_target_with_active_primary_label(target_list, input)
   local res = nil
-  for _, _352_ in ipairs(target_list) do
-    local _each_353_ = _352_
-    local target = _each_353_
-    local label = _each_353_["label"]
-    local label_state = _each_353_["label-state"]
+  for _, _338_ in ipairs(target_list) do
+    local _each_339_ = _338_
+    local label = _each_339_["label"]
+    local label_state = _each_339_["label-state"]
+    local target = _each_339_
     if res then break end
     if ((label == input) and (label_state == "active-primary")) then
       res = target
+    else
     end
   end
   return res
 end
 local function ignore_input_until_timeout(char_to_ignore)
-  local _355_ = get_input(opts.jump_on_partial_input_safety_timeout)
-  if (nil ~= _355_) then
-    local input = _355_
+  local _341_ = get_input(opts.jump_on_partial_input_safety_timeout)
+  if (nil ~= _341_) then
+    local input = _341_
     if (input ~= char_to_ignore) then
       return vim.fn.feedkeys(input, "i")
+    else
+      return nil
     end
+  else
+    return nil
   end
 end
-local sx = {state = {cold = {["reverse?"] = nil, ["x-mode?"] = nil, in1 = nil, in2 = nil}, dot = {in1 = nil, in2 = nil, in3 = nil}}}
+local sx = {state = {dot = {in1 = nil, in2 = nil, in3 = nil}, cold = {in1 = nil, in2 = nil, ["reverse?"] = nil, ["x-mode?"] = nil}}}
 sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
   local mode = api.nvim_get_mode().mode
   local op_mode_3f = mode:match("o")
@@ -1564,21 +1702,21 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
   if instant_repeat_3f then
     instant_state = repeat_invoc
   else
-  instant_state = nil
+    instant_state = nil
   end
   local cold_repeat_3f = (repeat_invoc == "cold")
   local dot_repeat_3f = (repeat_invoc == "dot")
   local invoked_as_reverse_3f = reverse_3f
   local reverse_3f0
   if cold_repeat_3f then
-    local function _359_(_241)
+    local function _345_(_241)
       if invoked_as_reverse_3f then
         return not _241
       else
         return _241
       end
     end
-    reverse_3f0 = _359_(self.state.cold["reverse?"])
+    reverse_3f0 = _345_(self.state.cold["reverse?"])
   else
     reverse_3f0 = reverse_3f
   end
@@ -1600,8 +1738,8 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     elseif cold_repeat_3f then
       return self.state.cold.in1
     else
-      local _363_
-      local function _364_()
+      local _349_
+      local function _350_()
         local res_2_auto
         do
           res_2_auto = get_input()
@@ -1609,9 +1747,10 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         hl:cleanup()
         return res_2_auto
       end
-      local function _365_()
+      local function _351_()
         if change_operation_3f() then
           handle_interrupted_change_op_21()
+        else
         end
         do
         end
@@ -1619,13 +1758,14 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         doau_when_exists("LightspeedLeave")
         return nil
       end
-      _363_ = (_364_() or _365_())
-      if (_363_ == _3cbackspace_3e) then
+      _349_ = (_350_() or _351_())
+      if (_349_ == _3cbackspace_3e) then
         backspace_repeat_3f = true
         new_search_3f = false
-        local function _367_()
+        local function _353_()
           if change_operation_3f() then
             handle_interrupted_change_op_21()
+          else
           end
           do
             echo_no_prev_search()
@@ -1634,94 +1774,111 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
           doau_when_exists("LightspeedLeave")
           return nil
         end
-        return (self.state.cold.in1 or _367_())
-      elseif (nil ~= _363_) then
-        local _in = _363_
+        return (self.state.cold.in1 or _353_())
+      elseif (nil ~= _349_) then
+        local _in = _349_
         return _in
+      else
+        return nil
       end
     end
   end
   local function update_state_2a(in1)
-    local function _373_(_371_)
-      local _arg_372_ = _371_
-      local cold = _arg_372_["cold"]
-      local dot = _arg_372_["dot"]
+    local function _359_(_357_)
+      local _arg_358_ = _357_
+      local cold = _arg_358_["cold"]
+      local dot = _arg_358_["dot"]
       if new_search_3f then
         if cold then
-          local _374_ = cold
-          _374_["in1"] = in1
-          _374_["x-mode?"] = x_mode_3f0
-          _374_["reverse?"] = reverse_3f0
-          self.state.cold = _374_
+          local _360_ = cold
+          _360_["in1"] = in1
+          _360_["x-mode?"] = x_mode_3f0
+          _360_["reverse?"] = reverse_3f0
+          self.state.cold = _360_
+        else
         end
         if dot then
           if dot_repeatable_op_3f then
             do
-              local _376_ = dot
-              _376_["in1"] = in1
-              _376_["x-mode?"] = x_mode_3f0
-              self.state.dot = _376_
+              local _362_ = dot
+              _362_["in1"] = in1
+              _362_["x-mode?"] = x_mode_3f0
+              self.state.dot = _362_
             end
             return nil
+          else
+            return nil
           end
+        else
+          return nil
         end
+      else
+        return nil
       end
     end
-    return _373_
+    return _359_
   end
   local jump_to_21
   do
     local first_jump_3f = true
-    local function _380_(target, _3fto_pre_eol_3f)
+    local function _366_(target, _3fto_pre_eol_3f)
       local to_pre_eol_3f0 = (_3fto_pre_eol_3f or to_pre_eol_3f)
       local adjusted_pos
-      local function _381_()
+      local function _367_()
         if to_eol_3f then
           if op_mode_3f then
             return push_cursor_21("fwd")
+          else
+            return nil
           end
         elseif to_pre_eol_3f0 then
           if (op_mode_3f and x_mode_3f0) then
             return push_cursor_21("fwd")
+          else
+            return nil
           end
         elseif x_mode_3f0 then
           push_cursor_21("fwd")
           if reverse_3f0 then
             return push_cursor_21("fwd")
+          else
+            return nil
           end
+        else
+          return nil
         end
       end
-      adjusted_pos = jump_to_21_2a(target, {["add-to-jumplist?"] = (first_jump_3f and not instant_repeat_3f), ["inclusive-motion?"] = (x_mode_3f0 and not reverse_3f0), ["reverse?"] = reverse_3f0, adjust = _381_, mode = mode})
+      adjusted_pos = jump_to_21_2a(target, {mode = mode, ["reverse?"] = reverse_3f0, ["inclusive-motion?"] = (x_mode_3f0 and not reverse_3f0), ["add-to-jumplist?"] = (first_jump_3f and not instant_repeat_3f), adjust = _367_})
       first_jump_3f = false
       return adjusted_pos
     end
-    jump_to_21 = _380_
+    jump_to_21 = _366_
   end
   local function highlight_new_curpos_and_op_area(from_pos, to_pos)
     local motion_force = get_motion_force(mode)
     local blockwise_3f = (motion_force == _3cctrl_v_3e)
-    local function _387_()
+    local function _373_()
       if reverse_3f0 then
         return to_pos
       else
         return from_pos
       end
     end
-    local _let_386_ = _387_()
-    local startline = _let_386_[1]
-    local startcol = _let_386_[2]
-    local start = _let_386_
-    local function _389_()
+    local _let_372_ = _373_()
+    local startline = _let_372_[1]
+    local startcol = _let_372_[2]
+    local start = _let_372_
+    local function _375_()
       if reverse_3f0 then
         return from_pos
       else
         return to_pos
       end
     end
-    local _let_388_ = _389_()
-    local _ = _let_388_[1]
-    local endcol = _let_388_[2]
-    local _end = _let_388_
+    local _let_374_ = _375_()
+    local _ = _let_374_[1]
+    local endcol = _let_374_[2]
+    local _end = _let_374_
     local top_left = {startline, min(startcol, endcol)}
     local new_curpos
     if op_mode_3f then
@@ -1735,50 +1892,57 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     end
     if not change_op_3f then
       highlight_cursor(new_curpos)
+    else
     end
     if op_mode_3f then
-      highlight_range(hl.group["pending-op-area"], map(dec, start), map(dec, _end), {["inclusive-motion?"] = (x_mode_3f0 and not reverse_3f0), ["motion-force"] = motion_force})
+      highlight_range(hl.group["pending-op-area"], map(dec, start), map(dec, _end), {["motion-force"] = motion_force, ["inclusive-motion?"] = (x_mode_3f0 and not reverse_3f0)})
+    else
     end
     return vim.cmd("redraw")
   end
   local function get_sublist(targets, ch)
-    local _394_ = targets.sublists[ch]
-    if (nil ~= _394_) then
-      local sublist = _394_
-      local _let_395_ = sublist
-      local _let_396_ = _let_395_[1]
-      local _let_397_ = _let_396_["pos"]
-      local line = _let_397_[1]
-      local col = _let_397_[2]
-      local rest = {(table.unpack or unpack)(_let_395_, 2)}
+    local _380_ = targets.sublists[ch]
+    if (nil ~= _380_) then
+      local sublist = _380_
+      local _let_381_ = sublist
+      local _let_382_ = _let_381_[1]
+      local _let_383_ = _let_382_["pos"]
+      local line = _let_383_[1]
+      local col = _let_383_[2]
+      local rest = (function (t, k) local mt = getmetatable(t) if "table" == type(mt) and mt.__fennelrest then return mt.__fennelrest(t, k) else return {(table.unpack or unpack)(t, k)} end end)(_let_381_, 2)
       local target_tail = {line, inc(col)}
       local prev_pos = vim.fn.searchpos("\\_.", "nWb")
       local cursor_touches_first_target_3f = same_pos_3f(target_tail, prev_pos)
       if (cold_repeat_3f and x_mode_3f0 and reverse_3f0 and cursor_touches_first_target_3f) then
         if not empty_3f(rest) then
           return rest
+        else
+          return nil
         end
       else
         return sublist
       end
+    else
+      return nil
     end
   end
   local function get_last_input(sublist, start_idx)
     local next_group_key = replace_keycodes(opts.cycle_group_fwd_key)
     local prev_group_key = replace_keycodes(opts.cycle_group_bwd_key)
     local function recur(group_offset, initial_invoc_3f)
-      local _401_
+      local _387_
       if (cold_repeat_3f or backspace_repeat_3f) then
-        _401_ = "cold"
+        _387_ = "cold"
       elseif instant_repeat_3f then
-        _401_ = "instant"
+        _387_ = "instant"
       else
-      _401_ = nil
+        _387_ = nil
       end
-      set_beacons(sublist, {["repeat"] = _401_})
+      set_beacons(sublist, {["repeat"] = _387_})
       do
         if (opts.grey_out_search_area and not (cold_repeat_3f or instant_repeat_3f or to_eol_3f)) then
           grey_out_search_area(reverse_3f0)
+        else
         end
         do
           light_up_beacons(sublist, start_idx)
@@ -1786,22 +1950,24 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         highlight_cursor()
         vim.cmd("redraw")
       end
-      local _404_
+      local _390_
       do
         local res_2_auto
         do
-          local function _405_()
+          local function _391_()
             if initial_invoc_3f then
               return opts.exit_after_idle_msecs.labeled
+            else
+              return nil
             end
           end
-          res_2_auto = get_input(_405_())
+          res_2_auto = get_input(_391_())
         end
         hl:cleanup()
-        _404_ = res_2_auto
+        _390_ = res_2_auto
       end
-      if (nil ~= _404_) then
-        local input = _404_
+      if (nil ~= _390_) then
+        local input = _390_
         if (sublist["autojump?"] and opts.labels and not empty_3f(opts.labels)) then
           return {input, 0}
         elseif (((input == next_group_key) or (input == prev_group_key)) and not instant_repeat_3f) then
@@ -1809,22 +1975,26 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
           local num_of_groups = ceil((#sublist / #labels))
           local max_offset = dec(num_of_groups)
           local group_offset_2a
-          local _407_
+          local _393_
           do
-            local _406_ = input
-            if (_406_ == next_group_key) then
-              _407_ = inc
+            local _392_ = input
+            if (_392_ == next_group_key) then
+              _393_ = inc
+            elseif true then
+              local _ = _392_
+              _393_ = dec
             else
-              local _ = _406_
-              _407_ = dec
+              _393_ = nil
             end
           end
-          group_offset_2a = clamp(_407_(group_offset), 0, max_offset)
+          group_offset_2a = clamp(_393_(group_offset), 0, max_offset)
           set_label_states_for_sublist(sublist, {["group-offset"] = group_offset_2a})
           return recur(group_offset_2a)
         else
           return {input, group_offset}
         end
+      else
+        return nil
       end
     end
     return recur(0, true)
@@ -1834,18 +2004,21 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     echo("")
     if (opts.grey_out_search_area and not (cold_repeat_3f or instant_repeat_3f or to_eol_3f)) then
       grey_out_search_area(reverse_3f0)
+    else
     end
     do
       if opts.highlight_unique_chars then
         highlight_unique_chars(reverse_3f0)
+      else
       end
     end
     highlight_cursor()
     vim.cmd("redraw")
+  else
   end
-  local _416_ = get_first_input()
-  if (nil ~= _416_) then
-    local in1 = _416_
+  local _402_ = get_first_input()
+  if (nil ~= _402_) then
+    local in1 = _402_
     local _
     to_eol_3f = (in1 == "\13")
     _ = nil
@@ -1859,19 +2032,21 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
     elseif dot_repeat_3f then
       prev_in2 = self.state.dot.in2
     else
-    prev_in2 = nil
+      prev_in2 = nil
     end
-    local _418_
-    local function _420_()
-      local t_419_ = instant_state
-      if (nil ~= t_419_) then
-        t_419_ = (t_419_).sublist
+    local _404_
+    local function _406_()
+      local t_405_ = instant_state
+      if (nil ~= t_405_) then
+        t_405_ = (t_405_).sublist
+      else
       end
-      return t_419_
+      return t_405_
     end
-    local function _422_()
+    local function _408_()
       if change_operation_3f() then
         handle_interrupted_change_op_21()
+      else
       end
       do
         echo_not_found((in1 .. (prev_in2 or "")))
@@ -1880,15 +2055,16 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
       doau_when_exists("LightspeedLeave")
       return nil
     end
-    _418_ = (_420_() or get_targets(in1, reverse_3f0) or _422_())
-    if ((type(_418_) == "table") and ((type((_418_)[1]) == "table") and ((type(((_418_)[1]).pair) == "table") and true and (nil ~= (((_418_)[1]).pair)[2]))) and ((_418_)[2] == nil)) then
-      local _0 = (((_418_)[1]).pair)[1]
-      local ch2 = (((_418_)[1]).pair)[2]
-      local only = (_418_)[1]
+    _404_ = (_406_() or get_targets(in1, reverse_3f0) or _408_())
+    if ((_G.type(_404_) == "table") and ((_G.type((_404_)[1]) == "table") and ((_G.type(((_404_)[1]).pair) == "table") and true and (nil ~= (((_404_)[1]).pair)[2]))) and ((_404_)[2] == nil)) then
+      local _0 = (((_404_)[1]).pair)[1]
+      local ch2 = (((_404_)[1]).pair)[2]
+      local only = (_404_)[1]
       if (new_search_3f or (ch2 == prev_in2)) then
         do
           if dot_repeatable_op_3f then
             set_dot_repeat(replace_keycodes(get_plug_key("sx", reverse_3f0, x_mode_3f0, "dot")))
+          else
           end
           update_state({cold = {in2 = ch2}, dot = {in2 = ch2, in3 = opts.labels[1]}})
           local to_pos = jump_to_21(only.pos, (ch2 == "\13"))
@@ -1899,6 +2075,7 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
               res_2_auto = ignore_input_until_timeout(ch2)
             end
             hl:cleanup()
+          else
           end
         end
         doau_when_exists("LightspeedSxLeave")
@@ -1907,6 +2084,7 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
       else
         if change_operation_3f() then
           handle_interrupted_change_op_21()
+        else
         end
         do
           echo_not_found((in1 .. prev_in2))
@@ -1915,36 +2093,41 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         doau_when_exists("LightspeedLeave")
         return nil
       end
-    elseif (nil ~= _418_) then
-      local targets = _418_
+    elseif (nil ~= _404_) then
+      local targets = _404_
       if not instant_repeat_3f then
-        local _428_ = targets
-        populate_sublists(_428_)
-        set_labels(_428_, to_eol_3f)
-        set_label_states(_428_)
+        local _414_ = targets
+        populate_sublists(_414_)
+        set_labels(_414_, to_eol_3f)
+        set_label_states(_414_)
+      else
       end
       if (new_search_3f and not to_eol_3f) then
         do
-          local _430_ = targets
-          set_shortcuts_and_populate_shortcuts_map(_430_)
-          set_beacons(_430_, {["repeat"] = nil})
+          local _416_ = targets
+          set_shortcuts_and_populate_shortcuts_map(_416_)
+          set_beacons(_416_, {["repeat"] = nil})
         end
         if (opts.grey_out_search_area and not (cold_repeat_3f or instant_repeat_3f or to_eol_3f)) then
           grey_out_search_area(reverse_3f0)
+        else
         end
         do
           light_up_beacons(targets)
         end
         highlight_cursor()
         vim.cmd("redraw")
+      else
       end
-      local _433_
-      local function _434_()
+      local _419_
+      local function _420_()
         if to_eol_3f then
           return ""
+        else
+          return nil
         end
       end
-      local function _435_()
+      local function _421_()
         local res_2_auto
         do
           res_2_auto = get_input()
@@ -1952,9 +2135,10 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         hl:cleanup()
         return res_2_auto
       end
-      local function _436_()
+      local function _422_()
         if change_operation_3f() then
           handle_interrupted_change_op_21()
+        else
         end
         do
         end
@@ -1962,24 +2146,26 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
         doau_when_exists("LightspeedLeave")
         return nil
       end
-      _433_ = (prev_in2 or _434_() or _435_() or _436_())
-      if (nil ~= _433_) then
-        local in2 = _433_
-        local _438_
+      _419_ = (prev_in2 or _420_() or _421_() or _422_())
+      if (nil ~= _419_) then
+        local in2 = _419_
+        local _424_
         do
-          local t_439_ = targets.shortcuts
-          if (nil ~= t_439_) then
-            t_439_ = (t_439_)[in2]
+          local t_425_ = targets.shortcuts
+          if (nil ~= t_425_) then
+            t_425_ = (t_425_)[in2]
+          else
           end
-          _438_ = t_439_
+          _424_ = t_425_
         end
-        if ((type(_438_) == "table") and ((type((_438_).pair) == "table") and true and (nil ~= ((_438_).pair)[2]))) then
-          local _0 = ((_438_).pair)[1]
-          local ch2 = ((_438_).pair)[2]
-          local shortcut = _438_
+        if ((_G.type(_424_) == "table") and ((_G.type((_424_).pair) == "table") and true and (nil ~= ((_424_).pair)[2]))) then
+          local _0 = ((_424_).pair)[1]
+          local ch2 = ((_424_).pair)[2]
+          local shortcut = _424_
           do
             if dot_repeatable_op_3f then
               set_dot_repeat(replace_keycodes(get_plug_key("sx", reverse_3f0, x_mode_3f0, "dot")))
+            else
             end
             update_state({cold = {in2 = ch2}, dot = {in2 = ch2, in3 = in2}})
             jump_to_21(shortcut.pos, (ch2 == "\13"))
@@ -1987,21 +2173,23 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
           doau_when_exists("LightspeedSxLeave")
           doau_when_exists("LightspeedLeave")
           return nil
-        else
-          local _0 = _438_
+        elseif true then
+          local _0 = _424_
           to_pre_eol_3f = (in2 == "\13")
           update_state({cold = {in2 = in2}})
-          local _442_
-          local function _444_()
-            local t_443_ = instant_state
-            if (nil ~= t_443_) then
-              t_443_ = (t_443_).sublist
+          local _428_
+          local function _430_()
+            local t_429_ = instant_state
+            if (nil ~= t_429_) then
+              t_429_ = (t_429_).sublist
+            else
             end
-            return t_443_
+            return t_429_
           end
-          local function _446_()
+          local function _432_()
             if change_operation_3f() then
               handle_interrupted_change_op_21()
+            else
             end
             do
               echo_not_found((in1 .. in2))
@@ -2010,12 +2198,13 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
             doau_when_exists("LightspeedLeave")
             return nil
           end
-          _442_ = (_444_() or get_sublist(targets, in2) or _446_())
-          if ((type(_442_) == "table") and (nil ~= (_442_)[1]) and ((_442_)[2] == nil)) then
-            local only = (_442_)[1]
+          _428_ = (_430_() or get_sublist(targets, in2) or _432_())
+          if ((_G.type(_428_) == "table") and (nil ~= (_428_)[1]) and ((_428_)[2] == nil)) then
+            local only = (_428_)[1]
             do
               if dot_repeatable_op_3f then
                 set_dot_repeat(replace_keycodes(get_plug_key("sx", reverse_3f0, x_mode_3f0, "dot")))
+              else
               end
               update_state({dot = {in2 = in2, in3 = opts.labels[1]}})
               jump_to_21(only.pos)
@@ -2023,26 +2212,27 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
             doau_when_exists("LightspeedSxLeave")
             doau_when_exists("LightspeedLeave")
             return nil
-          elseif ((type(_442_) == "table") and (nil ~= (_442_)[1])) then
-            local first = (_442_)[1]
-            local sublist = _442_
+          elseif ((_G.type(_428_) == "table") and (nil ~= (_428_)[1])) then
+            local first = (_428_)[1]
+            local sublist = _428_
             local autojump_3f = sublist["autojump?"]
             local curr_idx
-            local function _450_()
-              local t_449_ = instant_state
-              if (nil ~= t_449_) then
-                t_449_ = (t_449_).idx
+            local function _436_()
+              local t_435_ = instant_state
+              if (nil ~= t_435_) then
+                t_435_ = (t_435_).idx
+              else
               end
-              return t_449_
+              return t_435_
             end
-            local function _452_()
+            local function _438_()
               if autojump_3f then
                 return 1
               else
                 return 0
               end
             end
-            curr_idx = (_450_() or _452_())
+            curr_idx = (_436_() or _438_())
             local from_reverse_cold_repeat_3f
             if instant_repeat_3f then
               from_reverse_cold_repeat_3f = instant_state["from-reverse-cold-repeat?"]
@@ -2051,16 +2241,20 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
             end
             if (autojump_3f and not instant_repeat_3f) then
               jump_to_21(first.pos)
+            else
             end
-            local _455_
-            local function _456_()
+            local _441_
+            local function _442_()
               if (dot_repeat_3f and self.state.dot.in3) then
                 return {self.state.dot.in3, 0}
+              else
+                return nil
               end
             end
-            local function _457_()
+            local function _443_()
               if change_operation_3f() then
                 handle_interrupted_change_op_21()
+              else
               end
               do
               end
@@ -2068,58 +2262,60 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
               doau_when_exists("LightspeedLeave")
               return nil
             end
-            _455_ = (_456_() or get_last_input(sublist, inc(curr_idx)) or _457_())
-            if ((type(_455_) == "table") and (nil ~= (_455_)[1]) and (nil ~= (_455_)[2])) then
-              local in3 = (_455_)[1]
-              local group_offset = (_455_)[2]
-              local _459_
+            _441_ = (_442_() or get_last_input(sublist, inc(curr_idx)) or _443_())
+            if ((_G.type(_441_) == "table") and (nil ~= (_441_)[1]) and (nil ~= (_441_)[2])) then
+              local in3 = (_441_)[1]
+              local group_offset = (_441_)[2]
+              local _445_
               if not (op_mode_3f or (group_offset > 0)) then
-                _459_ = get_repeat_action(in3, "sx", x_mode_3f0, instant_repeat_3f, from_reverse_cold_repeat_3f)
+                _445_ = get_repeat_action(in3, "sx", x_mode_3f0, instant_repeat_3f, from_reverse_cold_repeat_3f)
               else
-              _459_ = nil
+                _445_ = nil
               end
-              if (nil ~= _459_) then
-                local action = _459_
+              if (nil ~= _445_) then
+                local action = _445_
                 local idx
                 do
-                  local _461_ = action
-                  if (_461_ == "repeat") then
+                  local _447_ = action
+                  if (_447_ == "repeat") then
                     idx = min(inc(curr_idx), #targets)
-                  elseif (_461_ == "revert") then
+                  elseif (_447_ == "revert") then
                     idx = max(dec(curr_idx), 1)
                   else
-                  idx = nil
+                    idx = nil
                   end
                 end
                 jump_to_21(sublist[idx].pos)
-                return sx:go(reverse_3f0, x_mode_3f0, {["from-reverse-cold-repeat?"] = from_reverse_cold_repeat_3f, idx = idx, in1 = in1, in2 = in2, sublist = sublist})
-              else
-                local _1 = _459_
-                local _463_ = get_target_with_active_primary_label(sublist, in3)
-                if (nil ~= _463_) then
-                  local target = _463_
+                return sx:go(reverse_3f0, x_mode_3f0, {in1 = in1, in2 = in2, sublist = sublist, idx = idx, ["from-reverse-cold-repeat?"] = from_reverse_cold_repeat_3f})
+              elseif true then
+                local _1 = _445_
+                local _449_ = get_target_with_active_primary_label(sublist, in3)
+                if (nil ~= _449_) then
+                  local target = _449_
                   do
                     if dot_repeatable_op_3f then
                       set_dot_repeat(replace_keycodes(get_plug_key("sx", reverse_3f0, x_mode_3f0, "dot")))
-                    end
-                    local _465_
-                    if (group_offset > 0) then
-                      _465_ = nil
                     else
-                      _465_ = in3
                     end
-                    update_state({dot = {in2 = in2, in3 = _465_}})
+                    local _451_
+                    if (group_offset > 0) then
+                      _451_ = nil
+                    else
+                      _451_ = in3
+                    end
+                    update_state({dot = {in2 = in2, in3 = _451_}})
                     jump_to_21(target.pos)
                   end
                   doau_when_exists("LightspeedSxLeave")
                   doau_when_exists("LightspeedLeave")
                   return nil
-                else
-                  local _2 = _463_
+                elseif true then
+                  local _2 = _449_
                   if autojump_3f then
                     do
                       if dot_repeatable_op_3f then
                         set_dot_repeat(replace_keycodes(get_plug_key("sx", reverse_3f0, x_mode_3f0, "dot")))
+                      else
                       end
                       vim.fn.feedkeys(in3, "i")
                     end
@@ -2129,6 +2325,7 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
                   else
                     if change_operation_3f() then
                       handle_interrupted_change_op_21()
+                    else
                     end
                     do
                     end
@@ -2136,39 +2333,55 @@ sx.go = function(self, reverse_3f, x_mode_3f, repeat_invoc)
                     doau_when_exists("LightspeedLeave")
                     return nil
                   end
+                else
+                  return nil
                 end
+              else
+                return nil
               end
+            else
+              return nil
             end
+          else
+            return nil
           end
+        else
+          return nil
         end
+      else
+        return nil
       end
+    else
+      return nil
     end
+  else
+    return nil
   end
 end
-local temporary_editor_opts = {["vim.bo.modeline"] = false, ["vim.wo.conceallevel"] = 0, ["vim.wo.scrolloff"] = 0}
+local temporary_editor_opts = {["vim.wo.conceallevel"] = 0, ["vim.wo.scrolloff"] = 0, ["vim.bo.modeline"] = false}
 local saved_editor_opts = {}
 local function save_editor_opts()
   for opt, _ in pairs(temporary_editor_opts) do
-    local _let_478_ = vim.split(opt, ".", true)
-    local _0 = _let_478_[1]
-    local scope = _let_478_[2]
-    local name = _let_478_[3]
-    local _479_
+    local _let_464_ = vim.split(opt, ".", true)
+    local _0 = _let_464_[1]
+    local scope = _let_464_[2]
+    local name = _let_464_[3]
+    local _465_
     if (opt == "vim.wo.scrolloff") then
-      _479_ = api.nvim_eval("&l:scrolloff")
+      _465_ = api.nvim_eval("&l:scrolloff")
     else
-      _479_ = _G.vim[scope][name]
+      _465_ = _G.vim[scope][name]
     end
-    saved_editor_opts[opt] = _479_
+    saved_editor_opts[opt] = _465_
   end
   return nil
 end
 local function set_editor_opts(opts0)
   for opt, val in pairs(opts0) do
-    local _let_481_ = vim.split(opt, ".", true)
-    local _ = _let_481_[1]
-    local scope = _let_481_[2]
-    local name = _let_481_[3]
+    local _let_467_ = vim.split(opt, ".", true)
+    local _ = _let_467_[1]
+    local scope = _let_467_[2]
+    local name = _let_467_[3]
     _G.vim[scope][name] = val
   end
   return nil
@@ -2181,38 +2394,38 @@ local function restore_editor_opts()
 end
 local function set_plug_keys()
   local plug_keys = {{"<Plug>Lightspeed_s", "sx:go(false)"}, {"<Plug>Lightspeed_S", "sx:go(true)"}, {"<Plug>Lightspeed_x", "sx:go(false, true)"}, {"<Plug>Lightspeed_X", "sx:go(true, true)"}, {"<Plug>Lightspeed_f", "ft:go(false)"}, {"<Plug>Lightspeed_F", "ft:go(true)"}, {"<Plug>Lightspeed_t", "ft:go(false, true)"}, {"<Plug>Lightspeed_T", "ft:go(true, true)"}, {"<Plug>Lightspeed_;_sx", "sx:go(false, nil, 'cold')"}, {"<Plug>Lightspeed_,_sx", "sx:go(true, nil, 'cold')"}, {"<Plug>Lightspeed_;_ft", "ft:go(false, nil, 'cold')"}, {"<Plug>Lightspeed_,_ft", "ft:go(true, nil, 'cold')"}}
-  for _, _482_ in ipairs(plug_keys) do
-    local _each_483_ = _482_
-    local lhs = _each_483_[1]
-    local rhs_call = _each_483_[2]
+  for _, _468_ in ipairs(plug_keys) do
+    local _each_469_ = _468_
+    local lhs = _each_469_[1]
+    local rhs_call = _each_469_[2]
     for _0, mode in ipairs({"n", "x", "o"}) do
       api.nvim_set_keymap(mode, lhs, ("<cmd>lua require'lightspeed'." .. rhs_call .. "<cr>"), {noremap = true, silent = true})
     end
   end
-  for _, _484_ in ipairs({{"<Plug>Lightspeed_dotrepeat_s", "sx:go(false, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_S", "sx:go(true, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_x", "sx:go(false, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_X", "sx:go(true, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_f", "ft:go(false, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_F", "ft:go(true, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_t", "ft:go(false, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_T", "ft:go(true, true, 'dot')"}}) do
-    local _each_485_ = _484_
-    local lhs = _each_485_[1]
-    local rhs_call = _each_485_[2]
+  for _, _470_ in ipairs({{"<Plug>Lightspeed_dotrepeat_s", "sx:go(false, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_S", "sx:go(true, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_x", "sx:go(false, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_X", "sx:go(true, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_f", "ft:go(false, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_F", "ft:go(true, false, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_t", "ft:go(false, true, 'dot')"}, {"<Plug>Lightspeed_dotrepeat_T", "ft:go(true, true, 'dot')"}}) do
+    local _each_471_ = _470_
+    local lhs = _each_471_[1]
+    local rhs_call = _each_471_[2]
     api.nvim_set_keymap("o", lhs, ("<cmd>lua require'lightspeed'." .. rhs_call .. "<cr>"), {noremap = true, silent = true})
   end
   return nil
 end
 local function set_default_keymaps()
   local default_keymaps = {{"n", "s", "<Plug>Lightspeed_s"}, {"n", "S", "<Plug>Lightspeed_S"}, {"x", "s", "<Plug>Lightspeed_s"}, {"x", "S", "<Plug>Lightspeed_S"}, {"o", "z", "<Plug>Lightspeed_s"}, {"o", "Z", "<Plug>Lightspeed_S"}, {"o", "x", "<Plug>Lightspeed_x"}, {"o", "X", "<Plug>Lightspeed_X"}, {"n", "f", "<Plug>Lightspeed_f"}, {"n", "F", "<Plug>Lightspeed_F"}, {"x", "f", "<Plug>Lightspeed_f"}, {"x", "F", "<Plug>Lightspeed_F"}, {"o", "f", "<Plug>Lightspeed_f"}, {"o", "F", "<Plug>Lightspeed_F"}, {"n", "t", "<Plug>Lightspeed_t"}, {"n", "T", "<Plug>Lightspeed_T"}, {"x", "t", "<Plug>Lightspeed_t"}, {"x", "T", "<Plug>Lightspeed_T"}, {"o", "t", "<Plug>Lightspeed_t"}, {"o", "T", "<Plug>Lightspeed_T"}, {"n", ";", "<Plug>Lightspeed_;_ft"}, {"x", ";", "<Plug>Lightspeed_;_ft"}, {"o", ";", "<Plug>Lightspeed_;_ft"}, {"n", ",", "<Plug>Lightspeed_,_ft"}, {"x", ",", "<Plug>Lightspeed_,_ft"}, {"o", ",", "<Plug>Lightspeed_,_ft"}}
-  for _, _486_ in ipairs(default_keymaps) do
-    local _each_487_ = _486_
-    local mode = _each_487_[1]
-    local lhs = _each_487_[2]
-    local rhs = _each_487_[3]
+  for _, _472_ in ipairs(default_keymaps) do
+    local _each_473_ = _472_
+    local mode = _each_473_[1]
+    local lhs = _each_473_[2]
+    local rhs = _each_473_[3]
     if ((vim.fn.mapcheck(lhs, mode) == "") and (vim.fn.hasmapto(rhs, mode) == 0)) then
       api.nvim_set_keymap(mode, lhs, rhs, {silent = true})
+    else
     end
   end
   return nil
 end
 init_highlight()
 set_plug_keys()
-set_default_keymaps()
 vim.cmd("augroup lightspeed_reinit_highlight\n   autocmd!\n   autocmd ColorScheme * lua require'lightspeed'.init_highlight()\n   augroup end")
 vim.cmd("augroup lightspeed_editor_opts\n   autocmd!\n   autocmd User LightspeedEnter lua require'lightspeed'.save_editor_opts(); require'lightspeed'.set_temporary_editor_opts()\n   autocmd User LightspeedLeave lua require'lightspeed'.restore_editor_opts()\n   augroup end")
-return {ft = ft, init_highlight = init_highlight, opts = opts, restore_editor_opts = restore_editor_opts, save_editor_opts = save_editor_opts, set_default_keymaps = set_default_keymaps, set_temporary_editor_opts = set_temporary_editor_opts, setup = setup, sx = sx}
+return {opts = opts, setup = setup, ft = ft, sx = sx, save_editor_opts = save_editor_opts, set_temporary_editor_opts = set_temporary_editor_opts, restore_editor_opts = restore_editor_opts, init_highlight = init_highlight, set_default_keymaps = set_default_keymaps}


### PR DESCRIPTION
In response to https://github.com/ggandor/lightspeed.nvim/issues/11 
This PR allowing to *NOT MAP AT ALL* some of the mappings
It separates mapping to 3 categories and adding 3 options to the `setup`
1. `override-s` - default `true` overrides `s`
2. `override-x`- default `true` overrides `x`
3. `override-motion` - default `true` overrides `fFtT...`