### PR TITLE
Ignore generated helptags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
(Neo)vim will put generated help tags into `./doc/tags`. This causes the repository to appear modified. All major Vim plugins contain a `.gitignore` for this reason.