### PR TITLE
Fix error when special_keys doesn't contain both match groups

### DIFF
--- a/fnl/lightspeed.fnl
+++ b/fnl/lightspeed.fnl
@@ -1309,8 +1309,9 @@ sub-table containing label-target key-value pairs for these targets."
                               (get-targetable-windows reverse? omni?))
                             (when instant-repeat? instant-state.target-windows))
         spec-keys (setmetatable {} {:__index
-                                    (fn [_ k] (replace-keycodes
-                                                (. opts.special_keys k)))})]
+                                    (fn [_ k] (let [prop (. opts.special_keys k)]
+                                                (if (not= prop nil)  
+                                                        (replace-keycodes prop))))})]
 
     ; Top-level vars
 

--- a/lua/lightspeed.lua
+++ b/lua/lightspeed.lua
@@ -1978,7 +1978,12 @@ sx.go = function(self, _379_)
   _3ftarget_windows = (_386_() or _388_())
   local spec_keys
   local function _390_(_, k)
-    return replace_keycodes(opts.special_keys[k])
+    local prop = opts.special_keys[k]
+    if (prop ~= nil) then
+      return replace_keycodes(prop)
+    else
+      return nil
+    end
   end
   spec_keys = setmetatable({}, {__index = _390_})
   local new_search_3f = not repeat_invoc


### PR DESCRIPTION
When setting up lightspeed, if `special_keys` does not contain both `prev_match_group` and `next_match_group`, then 'sneaking' when there is more than 18 matches errors when typing the third character errors with:
```console
E5108: Error executing lua: ...ite\pack\packer\start\lightspeed.nvim/lua/lightspeed.lua:2246: Expected lua string
stack traceback:
	[C]: in function '__index'
	...ite\pack\packer\start\lightspeed.nvim/lua/lightspeed.lua:2246: in function '_438_'
	...ite\pack\packer\start\lightspeed.nvim/lua/lightspeed.lua:2248: in function 'get_last_input'
	...ite\pack\packer\start\lightspeed.nvim/lua/lightspeed.lua:2594: in function 'go'
	...a\site\pack\packer\start\lightspeed.nvim\plugin\init.lua:3: in function <...a\site\pack\packer\start\lightspeed.nvim\plugin\init.lua:3>
```

When the third character is being processed, logic on [line 2246 of the generated script](https://github.com/ggandor/lightspeed.nvim/blob/299eefa6a9e2d881f1194587c573dad619fdb96f/lua/lightspeed.lua#L2246) checks if the input is equal to the keycodes of one of the special keys, and the function that maps the `special_keys` keys to keycodes doesn't check if the property doesn't exist and eventually calls `vim.api.nvim_replace_termcodes` with `nil`, which causes the error.

To check that you can run neovim with:
```lua
vim.cmd 'packadd packer.nvim'

require('packer').startup(function(use)  
    use{ 'ggandor/lightspeed.nvim' }
end)

require('lightspeed').setup{ special_keys = {} }
```
and type
```
19iab<cr><esc>ggO<esc>sab[[the next character causes the error]]
```

This pull requests adds the `nil` check and makes the function return `nil` in case the property doesn't exist.